### PR TITLE
Advanced Activity Intelligence & Tracking Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ installer/Output/*
 !docs/
 !RustPlusDesktop/*.png
 !RustPlusDesktop/*.jpg
+RustPlusDesktop/RustPlusDesk_lbvqmzga_wpftmp.csproj
+RustPlusDesktop/Setup.iss

--- a/RustPlusDesktop/App.xaml.cs
+++ b/RustPlusDesktop/App.xaml.cs
@@ -56,14 +56,15 @@ public partial class App : Application
                 TrackingService.StartPolling(host, port, name);
         }
 
-        if (isBackgroundArg || TrackingService.StartMinimizedEnabled)
+        if (isBackgroundArg && TrackingService.StartMinimizedEnabled)
         {
-            // Run silently in tray or started minimized
+            // Started by Windows (auto-start) and minimized is enabled
             if (e.Args.Length > 0 && e.Args[0].StartsWith("rustplus://", StringComparison.OrdinalIgnoreCase))
                 ShowMainWindow();
         }
         else
         {
+            // Manual start by user, or auto-start with minimized disabled
             ShowMainWindow();
         }
 
@@ -94,15 +95,40 @@ public partial class App : Application
         _trayIcon.Visible = true;
 
         var menu = new System.Windows.Forms.ContextMenuStrip();
-        menu.Items.Add("Open Rust+ Desk", null, (s, e) => ShowMainWindow());
-        menu.Items.Add("-");
-        menu.Items.Add("Exit", null, (s, e) => {
-            _trayIcon.Visible = false;
-            Current.Shutdown();
-        });
+        
+        // Dynamic update on open
+        menu.Opening += (s, e) =>
+        {
+            menu.Items.Clear();
+            var status = TrackingService.IsTracking ? "Active" : "Idle";
+            var last = TrackingService.LastPullTime?.ToString("HH:mm:ss") ?? "--:--:--";
+            
+            var statusItem = new System.Windows.Forms.ToolStripMenuItem($"Tracking: {status}");
+            statusItem.Enabled = false;
+            menu.Items.Add(statusItem);
+            
+            var lastItem = new System.Windows.Forms.ToolStripMenuItem($"Last update: {last}");
+            lastItem.Enabled = false;
+            menu.Items.Add(lastItem);
+            
+            menu.Items.Add(new System.Windows.Forms.ToolStripSeparator());
+            menu.Items.Add("Open Rust+ Desk", null, (s, ex) => ShowMainWindow());
+            menu.Items.Add(new System.Windows.Forms.ToolStripSeparator());
+            menu.Items.Add("Exit", null, (s, ex) => {
+                _trayIcon.Visible = false;
+                Current.Shutdown();
+            });
+        };
 
         _trayIcon.ContextMenuStrip = menu;
         _trayIcon.DoubleClick += (s, e) => ShowMainWindow();
+        
+        // Also update tray tooltip periodically or on event
+        TrackingService.OnOnlinePlayersUpdated += () => {
+            var last = TrackingService.LastPullTime?.ToString("HH:mm:ss") ?? "--:--";
+            if (_trayIcon != null)
+                _trayIcon.Text = $"Rust+ Desk (Tracking {last})";
+        };
     }
 
     protected override void OnExit(ExitEventArgs e)

--- a/RustPlusDesktop/App.xaml.cs
+++ b/RustPlusDesktop/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System;
 using System.IO;
 using System.IO.Pipes;
@@ -7,6 +7,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using RustPlusDesk.Views;
+using RustPlusDesk.Services;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using Application = System.Windows.Application;
 
 namespace RustPlusDesk;
 
@@ -17,6 +22,7 @@ public partial class App : Application
     private const string PipeName = "RustPlusDeskLinkPipe";
 
     private MainWindow? _main;
+    private System.Windows.Forms.NotifyIcon? _trayIcon;
 
     protected override void OnStartup(StartupEventArgs e)
     {
@@ -24,28 +30,85 @@ public partial class App : Application
 
         EnsureUrlProtocolRegistered();
 
+        bool isBackgroundArg = e.Args.Contains("--background");
         bool createdNew;
         _single = new Mutex(initiallyOwned: true, name: SingleMutexName, createdNew: out createdNew);
 
         if (!createdNew)
         {
-            // schon laufend → Link (falls vorhanden) an laufende Instanz schicken und beenden
+            // Already running
             if (e.Args.Length > 0 && e.Args[0].StartsWith("rustplus://", StringComparison.OrdinalIgnoreCase))
                 _ = SendLinkToRunningInstanceAsync(e.Args[0]);
+            else if (!isBackgroundArg)
+                _ = SendCommandToRunningInstanceAsync("SHOWUI");
+
             Shutdown();
             return;
         }
 
-        // erste/laufende Instanz
-        _main = new MainWindow();
-        _main.Show();
+        SetupTrayIcon();
 
-        // Pipe-Server für zukünftige Links starten
+        // Start polling if enabled and we have a server
+        if (TrackingService.IsBackgroundTrackingEnabled)
+        {
+            var (host, port, name) = TrackingService.LastServer;
+            if (!string.IsNullOrEmpty(host))
+                TrackingService.StartPolling(host, port, name);
+        }
+
+        if (isBackgroundArg || TrackingService.StartMinimizedEnabled)
+        {
+            // Run silently in tray or started minimized
+            if (e.Args.Length > 0 && e.Args[0].StartsWith("rustplus://", StringComparison.OrdinalIgnoreCase))
+                ShowMainWindow();
+        }
+        else
+        {
+            ShowMainWindow();
+        }
+
         _ = StartPipeServerAsync();
 
-        // Falls diese Instanz selbst mit Link gestartet wurde: direkt verarbeiten
         if (e.Args.Length > 0 && e.Args[0].StartsWith("rustplus://", StringComparison.OrdinalIgnoreCase))
-            _main.HandleRustPlusLink(e.Args[0]);
+            _main?.HandleRustPlusLink(e.Args[0]);
+    }
+
+    private void ShowMainWindow()
+    {
+        if (_main == null)
+        {
+            _main = new MainWindow();
+            _main.Closed += (s, ev) => _main = null;
+        }
+        _main.Show();
+        _main.WindowState = WindowState.Normal;
+        _main.Activate();
+        _main.Topmost = true; _main.Topmost = false;
+    }
+
+    private void SetupTrayIcon()
+    {
+        _trayIcon = new System.Windows.Forms.NotifyIcon();
+        _trayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName!);
+        _trayIcon.Text = "Rust+ Desk Tracker";
+        _trayIcon.Visible = true;
+
+        var menu = new System.Windows.Forms.ContextMenuStrip();
+        menu.Items.Add("Open Rust+ Desk", null, (s, e) => ShowMainWindow());
+        menu.Items.Add("-");
+        menu.Items.Add("Exit", null, (s, e) => {
+            _trayIcon.Visible = false;
+            Current.Shutdown();
+        });
+
+        _trayIcon.ContextMenuStrip = menu;
+        _trayIcon.DoubleClick += (s, e) => ShowMainWindow();
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        if (_trayIcon != null) _trayIcon.Visible = false;
+        base.OnExit(e);
     }
 
     private static void EnsureUrlProtocolRegistered()
@@ -63,18 +126,20 @@ public partial class App : Application
         catch { /* unkritisch */ }
     }
 
-    private static async Task SendLinkToRunningInstanceAsync(string link)
+    private static async Task SendCommandToRunningInstanceAsync(string cmd)
     {
         try
         {
             using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
             await client.ConnectAsync(1500);
-            var data = Encoding.UTF8.GetBytes(link + "\n");
+            var data = Encoding.UTF8.GetBytes(cmd + "\n");
             await client.WriteAsync(data, 0, data.Length);
             await client.FlushAsync();
         }
-        catch { /* wenn keiner lauscht: ignore */ }
+        catch { }
     }
+
+    private static async Task SendLinkToRunningInstanceAsync(string link) => await SendCommandToRunningInstanceAsync(link);
 
     private async Task StartPipeServerAsync()
     {
@@ -87,19 +152,24 @@ public partial class App : Application
                 await server.WaitForConnectionAsync();
                 using var reader = new StreamReader(server, Encoding.UTF8);
                 var link = await reader.ReadLineAsync();
-                if (!string.IsNullOrWhiteSpace(link) &&
-                    link.StartsWith("rustplus://", StringComparison.OrdinalIgnoreCase) &&
-                    _main != null)
+                if (!string.IsNullOrWhiteSpace(link) && _main != null)
                 {
                     _main.Dispatcher.Invoke(() =>
                     {
-                        // Fenster in den Vordergrund holen
-                        if (_main.WindowState == WindowState.Minimized) _main.WindowState = WindowState.Normal;
-                        _main.Activate();
-                        _main.Topmost = true; _main.Topmost = false;
-
-                        _main.HandleRustPlusLink(link);
+                        if (link == "SHOWUI")
+                        {
+                            ShowMainWindow();
+                        }
+                        else if (link.StartsWith("rustplus://", StringComparison.OrdinalIgnoreCase))
+                        {
+                            ShowMainWindow();
+                            _main.HandleRustPlusLink(link);
+                        }
                     });
+                }
+                else if (link == "SHOWUI")
+                {
+                    Dispatcher.Invoke(ShowMainWindow);
                 }
             }
             catch

--- a/RustPlusDesktop/MainWindow.xaml
+++ b/RustPlusDesktop/MainWindow.xaml
@@ -850,6 +850,84 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                         HorizontalAlignment="Right">
                         <TextBlock Text="Players:"/>
                         <TextBlock Text="{Binding ServerPlayers}" FontWeight="SemiBold" Margin="4,0,0,0"/>
+
+                        <Button x:Name="BtnServerBM" Content="BM" Width="24" Height="18" Padding="0" Margin="6,0,0,0"
+                                FontSize="9" FontWeight="Bold" Style="{StaticResource GhostButton}"
+                                ToolTip="Open Server on BattleMetrics" Click="BtnServerBM_Click" Visibility="Collapsed"/>
+
+                        <ToggleButton x:Name="BtnShowOnline" Content="▼" Margin="4,0,0,0" Width="18" Height="18" 
+                                      Background="Transparent" BorderThickness="0" Foreground="White" 
+                                      ToolTip="Show Online Players" Click="BtnShowOnline_Click" />
+                        
+                        <Popup x:Name="PopupOnlinePlayers" PlacementTarget="{Binding ElementName=BtnShowOnline}" 
+                               IsOpen="{Binding IsChecked, ElementName=BtnShowOnline}" StaysOpen="False" 
+                               AllowsTransparency="True" PopupAnimation="Fade" VerticalOffset="20">
+                            <Border Background="{DynamicResource Surface}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="6" Padding="6" MaxHeight="350" Width="320">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Text="Online Players" FontWeight="Bold" Margin="0,0,0,6" Grid.Row="0"/>
+                                    
+                                    <!-- Manual Add Section -->
+                                    <DockPanel Grid.Row="1" Margin="0,0,0,8">
+                                        <Button x:Name="BtnAddManual" DockPanel.Dock="Right" Content="Track ID" 
+                                                Style="{StaticResource GhostButton}" FontSize="10" Padding="4,0" 
+                                                Click="BtnAddManual_Click" Margin="4,0,0,0"/>
+                                        <TextBox x:Name="TxtManualBMId" Padding="4,1" FontSize="10" 
+                                                 Background="#25272a" Foreground="White" BorderThickness="1" 
+                                                 BorderBrush="#333" Tag="Manual BM ID..."/>
+                                    </DockPanel>
+
+                                    <!-- Online List Filter -->
+                                    <TextBox x:Name="TxtOnlineFilter" Grid.Row="1" Margin="0,0,0,6" Visibility="Collapsed" 
+                                             Padding="4,2" FontSize="10" Background="#1a1c1e" Foreground="White" 
+                                             BorderThickness="1" BorderBrush="#333" GotFocus="TxtOnlineFilter_GotFocus" 
+                                             LostFocus="TxtOnlineFilter_LostFocus" TextChanged="TxtOnlineFilter_TextChanged"/>
+
+                                    <TextBlock x:Name="TxtOnlinePlayersStatus" Text="Loading..." FontSize="11" Foreground="{DynamicResource TextSubtle}" Margin="0,0,0,6" Grid.Row="1" Visibility="Collapsed"/>
+                                    <ListBox x:Name="ListOnlinePlayers" Grid.Row="2" Background="Transparent" BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid Margin="0,2">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <StackPanel Orientation="Horizontal" Grid.Column="0">
+                                                        <Ellipse Width="8" Height="8" Fill="{DynamicResource CbAccent}" Margin="0,0,6,0" VerticalAlignment="Center" x:Name="StatusDot"/>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Width="130" ToolTip="{Binding Name}"/>
+                                                    </StackPanel>
+                                                    <TextBlock Grid.Column="1" Text="{Binding PlayTimeStr}" Foreground="{DynamicResource TextSubtle}" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="11" Width="50"/>
+                                                    <Button Grid.Column="2" x:Name="BtnPlayerBM" Content="BM" Click="BtnPlayerBM_Click" Style="{StaticResource GhostButton}" Padding="4,2" FontSize="10" Margin="0,0,4,0" Tag="{Binding}"/>
+                                                    <Button Grid.Column="3" x:Name="BtnAction" Content="Track" Click="BtnTrackPlayer_Click" Style="{StaticResource GhostButton}" Padding="6,2" FontSize="10" Margin="0" Tag="{Binding}" Width="50"/>
+                                                </Grid>
+                                                <DataTemplate.Triggers>
+                                                    <DataTrigger Binding="{Binding IsTracked}" Value="True">
+                                                        <Setter TargetName="StatusDot" Property="Fill" Value="#FFD166"/>
+                                                        <Setter TargetName="BtnAction" Property="Content" Value="Details"/>
+                                                    </DataTrigger>
+                                                    <!-- Invisible button until hover -->
+                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                        <Setter TargetName="BtnAction" Property="Opacity" Value="0.2"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="BtnAction" Property="Opacity" Value="1"/>
+                                                    </Trigger>
+                                                </DataTemplate.Triggers>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                    <Button x:Name="BtnViewTracking" Grid.Row="3" Content="View Tracking Analysis" Margin="0,6,0,0" Style="{StaticResource PrimaryButton}" Click="BtnViewTracking_Click" />
+                                </Grid>
+                            </Border>
+                        </Popup>
+
                         <TextBlock Text="  |  Queue:" Margin="6,0,0,0"/>
                         <TextBlock Text="{Binding ServerQueue}" FontWeight="SemiBold" Margin="4,0,0,0"/>
                         <TextBlock Text="  |  Server Time:" Margin="6,0,0,0"/>

--- a/RustPlusDesktop/MainWindow.xaml
+++ b/RustPlusDesktop/MainWindow.xaml
@@ -810,6 +810,37 @@
                        Text="Click Listen (Pairing) to pair new servers. Rightclick for more options." 
                        FontSize="9.5" FontStyle="Italic"/>
 
+                    <Grid Margin="0,4,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Orientation="Horizontal">
+                            <Ellipse x:Name="TrackingPulse" Width="8" Height="8" Fill="#62D38B" Margin="0,0,8,0" VerticalAlignment="Center">
+                                <Ellipse.Style>
+                                    <Style TargetType="Ellipse">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTrackingActive}" Value="True">
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard x:Name="Pulse">
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" From="1" To="0.3" Duration="0:0:1" AutoReverse="True" RepeatBehavior="Forever"/>
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                                <DataTrigger.ExitActions>
+                                                    <StopStoryboard BeginStoryboardName="Pulse"/>
+                                                </DataTrigger.ExitActions>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Ellipse.Style>
+                            </Ellipse>
+                            <TextBlock x:Name="TxtTrackingStatus" Text="Tracking Active" FontWeight="SemiBold" FontSize="11" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <TextBlock x:Name="TxtLastPull" Grid.Column="1" Text="Last pull: --:--" Foreground="{DynamicResource TextSubtle}" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    </Grid>
+
                     <Separator Margin="0,12,0,12"/>
                 </StackPanel>
 

--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -9960,15 +9960,30 @@ public partial class MainWindow : Window
         Dispatcher.Invoke(() =>
         {
             RefreshOnlinePlayersList();
-            
             // Update tracking status indicator
+            bool anyTracked = TrackingService.GetTrackedPlayers().Count > 0;
             _vm.IsTrackingActive = TrackingService.IsTracking;
-            TxtTrackingStatus.Text = TrackingService.IsTracking ? "Tracking Active" : "Tracking Idle";
-            TxtTrackingStatus.Foreground = TrackingService.IsTracking ? Brushes.White : Brushes.Gray;
+
+            if (!anyTracked)
+            {
+                TxtTrackingStatus.Text = "Add players to tracker to start tracking";
+                TxtTrackingStatus.Foreground = Brushes.Gray;
+                TxtTrackingStatus.FontStyle = FontStyles.Italic;
+            }
+            else
+            {
+                TxtTrackingStatus.Text = TrackingService.IsTracking ? "Tracking Active" : "Tracking Idle";
+                TxtTrackingStatus.Foreground = TrackingService.IsTracking ? Brushes.White : Brushes.Gray;
+                TxtTrackingStatus.FontStyle = FontStyles.Normal;
+            }
             
-            if (TrackingService.LastPullTime.HasValue)
+            if (TrackingService.LastPullTime.HasValue && anyTracked)
             {
                 TxtLastPull.Text = $"Last pull: {TrackingService.LastPullTime.Value:HH:mm:ss}";
+            }
+            else
+            {
+                TxtLastPull.Text = "Last pull: --:--";
             }
         });
     }

--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -927,6 +927,18 @@ public partial class MainWindow : Window
 
     // throttle: nicht bei jedem Tick refreshe n
     private DateTime _lastTeamRefresh = DateTime.MinValue;
+    protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+    {
+        if (TrackingService.CloseToTrayEnabled)
+        {
+            e.Cancel = true;
+            this.Hide();
+            return;
+        }
+
+        base.OnClosing(e);
+    }
+
     public MainWindow()
     {
         // Nur freiwillig zum Diagnostizieren:
@@ -10140,9 +10152,47 @@ public partial class MainWindow : Window
         Grid.SetRow(searchBox, 1);
         grid.Children.Add(searchBox);
 
+        // Background tracking toggle
+        var bgCheck = new System.Windows.Controls.CheckBox { 
+            Content = "Always track in background (auto-starts with Windows)",
+            Foreground = Brushes.LightGray,
+            Margin = new Thickness(0,0,0,5),
+            IsChecked = TrackingService.IsBackgroundTrackingEnabled
+        };
+        bgCheck.Checked += (s, e) => SetBackgroundTracking(true);
+        bgCheck.Unchecked += (s, e) => SetBackgroundTracking(false);
+
+        var trayCheck = new System.Windows.Controls.CheckBox { 
+            Content = "Minimize to tray when closing window",
+            Foreground = Brushes.LightGray,
+            Margin = new Thickness(0,0,0,5),
+            IsChecked = TrackingService.CloseToTrayEnabled
+        };
+        trayCheck.Checked += (s, e) => TrackingService.CloseToTrayEnabled = true;
+        trayCheck.Unchecked += (s, e) => TrackingService.CloseToTrayEnabled = false;
+
+        var minCheck = new System.Windows.Controls.CheckBox { 
+            Content = "Start application minimized in tray",
+            Foreground = Brushes.LightGray,
+            Margin = new Thickness(0,0,0,10),
+            IsChecked = TrackingService.StartMinimizedEnabled
+        };
+        minCheck.Checked += (s, e) => TrackingService.StartMinimizedEnabled = true;
+        minCheck.Unchecked += (s, e) => TrackingService.StartMinimizedEnabled = false;
+
+        var listContainer = new DockPanel();
+        var controlsStack = new StackPanel();
+        controlsStack.Children.Add(bgCheck);
+        controlsStack.Children.Add(trayCheck);
+        controlsStack.Children.Add(minCheck);
+        listContainer.Children.Add(controlsStack);
+        DockPanel.SetDock(controlsStack, Dock.Top);
+        
         var list = new ListBox { Background = Brushes.Transparent, BorderThickness = new Thickness(0), Foreground = Brushes.White };
-        Grid.SetRow(list, 2);
-        grid.Children.Add(list);
+        listContainer.Children.Add(list);
+
+        Grid.SetRow(listContainer, 2);
+        grid.Children.Add(listContainer);
 
         Action<string> refreshList = null;
         refreshList = (filter) => {
@@ -10208,6 +10258,32 @@ public partial class MainWindow : Window
 
         win.Content = grid;
         win.ShowDialog();
+    }
+
+    private void SetBackgroundTracking(bool enable)
+    {
+        TrackingService.IsBackgroundTrackingEnabled = enable;
+        
+        try
+        {
+            var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true);
+            if (key != null)
+            {
+                if (enable)
+                {
+                    var exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName!;
+                    key.SetValue("RustPlusDeskTracker", $"\"{exePath}\" --background");
+                }
+                else
+                {
+                    key.DeleteValue("RustPlusDeskTracker", false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"[error] Failed to update startup registry: {ex.Message}");
+        }
     }
 
     private void ShowTrackingAnalysisWindow(string? bmId = null)

--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -989,6 +989,12 @@ public partial class MainWindow : Window
         HydrateSteamUiFromStorage();   // <= HIER
         _statusTimer.Tick += async (_, __) => await UpdateServerStatusAsync();
         ListServers.ItemsSource = _vm.Servers;
+        
+        // Initial tracking status update and hook global events
+        TrackingService.OnOnlinePlayersUpdated -= OnOnlinePlayersUpdated;
+        TrackingService.OnOnlinePlayersUpdated += OnOnlinePlayersUpdated;
+        OnOnlinePlayersUpdated();
+        
         // Einmal erzeugen (falls du den Stub behalten willst: try/fallback – aber nur EINMAL zuweisen)
 
         _pairing = new PairingListenerRealProcess(AppendLog);
@@ -3570,8 +3576,6 @@ public partial class MainWindow : Window
             _connectedProfile = _vm.Selected;
 
             // Start Battlemetrics tracking polling for this server
-            TrackingService.OnOnlinePlayersUpdated -= OnOnlinePlayersUpdated;
-            TrackingService.OnOnlinePlayersUpdated += OnOnlinePlayersUpdated;
             TrackingService.StartPolling(_vm.Selected.Host ?? "", _vm.Selected.Port, _vm.Selected.Name ?? "");
 
             // Allow socket to stabilize before firing requests
@@ -9956,6 +9960,16 @@ public partial class MainWindow : Window
         Dispatcher.Invoke(() =>
         {
             RefreshOnlinePlayersList();
+            
+            // Update tracking status indicator
+            _vm.IsTrackingActive = TrackingService.IsTracking;
+            TxtTrackingStatus.Text = TrackingService.IsTracking ? "Tracking Active" : "Tracking Idle";
+            TxtTrackingStatus.Foreground = TrackingService.IsTracking ? Brushes.White : Brushes.Gray;
+            
+            if (TrackingService.LastPullTime.HasValue)
+            {
+                TxtLastPull.Text = $"Last pull: {TrackingService.LastPullTime.Value:HH:mm:ss}";
+            }
         });
     }
 

--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -3556,6 +3556,12 @@ public partial class MainWindow : Window
             _vm.Selected.IsConnected = true;
             AppendLog("Connected.");
             _connectedProfile = _vm.Selected;
+
+            // Start Battlemetrics tracking polling for this server
+            TrackingService.OnOnlinePlayersUpdated -= OnOnlinePlayersUpdated;
+            TrackingService.OnOnlinePlayersUpdated += OnOnlinePlayersUpdated;
+            TrackingService.StartPolling(_vm.Selected.Host ?? "", _vm.Selected.Port, _vm.Selected.Name ?? "");
+
             // Allow socket to stabilize before firing requests
             await Task.Delay(1000);
             // EINMAL casten und überall dieselbe Variable verwenden
@@ -9927,10 +9933,333 @@ public partial class MainWindow : Window
 
                 // 9) Zeitstempel für diese Kombo updaten
                 rule.LastAnnouncements[sig] = DateTime.UtcNow;
+            }           // end foreach order
+            }           // end foreach shop
+        }               // end foreach rule
+    }
+    // ─── ONLINE PLAYERS & TRACKING ───────────────────────────────────────────
+
+    private void OnOnlinePlayersUpdated()
+    {
+        Dispatcher.Invoke(() =>
+        {
+            RefreshOnlinePlayersList();
+        });
+    }
+
+    private void RefreshOnlinePlayersList()
+    {
+        var players = TrackingService.LastOnlinePlayers;
+        
+        // Dynamic Filter visibility
+        if (players.Count > 0) {
+            TxtOnlineFilter.Visibility = Visibility.Visible;
+            if (string.IsNullOrEmpty(TxtOnlineFilter.Text)) {
+                TxtOnlineFilter.Text = "Filter players...";
+                TxtOnlineFilter.Foreground = Brushes.Gray;
+            }
+        } else {
+            TxtOnlineFilter.Visibility = Visibility.Collapsed;
+        }
+
+        var filterTxt = TxtOnlineFilter.Text;
+        if (!string.IsNullOrEmpty(filterTxt) && filterTxt != "Filter players...")
+        {
+            players = players.Where(p => p.Name.Contains(filterTxt, StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+
+        ListOnlinePlayers.ItemsSource = null;
+        ListOnlinePlayers.ItemsSource = players;
+
+        if (TrackingService.LastOnlinePlayers.Count == 0)
+        {
+            TxtOnlinePlayersStatus.Text = TrackingService.StatusMessage;
+            TxtOnlinePlayersStatus.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            TxtOnlinePlayersStatus.Visibility = Visibility.Collapsed;
+        }
+
+        // Update Server BM button visibility
+        BtnServerBM.Visibility = string.IsNullOrEmpty(TrackingService.CurrentServerBMId) 
+            ? Visibility.Collapsed 
+            : Visibility.Visible;
+    }
+
+    private void TxtOnlineFilter_GotFocus(object sender, RoutedEventArgs e) {
+        if (TxtOnlineFilter.Text == "Filter players...") {
+            TxtOnlineFilter.Text = "";
+            TxtOnlineFilter.Foreground = Brushes.White;
+        }
+    }
+    private void TxtOnlineFilter_LostFocus(object sender, RoutedEventArgs e) {
+        if (string.IsNullOrWhiteSpace(TxtOnlineFilter.Text)) {
+            TxtOnlineFilter.Text = "Filter players...";
+            TxtOnlineFilter.Foreground = Brushes.Gray;
+        }
+    }
+    private void TxtOnlineFilter_TextChanged(object sender, TextChangedEventArgs e) {
+        if (TxtOnlineFilter.Text != "Filter players...") RefreshOnlinePlayersList();
+    }
+
+    private async void BtnShowOnline_Click(object sender, RoutedEventArgs e)
+    {
+        // When user opens the popup, trigger a fresh fetch
+        if (BtnShowOnline.IsChecked == true)
+        {
+            if (_vm.Selected == null || string.IsNullOrEmpty(_vm.Selected.Host))
+            {
+                TxtOnlinePlayersStatus.Text = "Connect to a server to load players list";
+                TxtOnlinePlayersStatus.Visibility = Visibility.Visible;
+                ListOnlinePlayers.ItemsSource = null;
+                return;
+            }
+
+            TxtOnlinePlayersStatus.Text = "Loading from Battlemetrics...";
+            TxtOnlinePlayersStatus.Visibility = Visibility.Visible;
+            ListOnlinePlayers.ItemsSource = null;
+
+            try
+            {
+                await TrackingService.FetchOnlinePlayersNowAsync();
+            }
+            catch (Exception ex)
+            {
+                TxtOnlinePlayersStatus.Text = $"Error: {ex.Message}";
+                TxtOnlinePlayersStatus.Visibility = Visibility.Visible;
             }
         }
     }
-}
+
+    private void BtnTrackPlayer_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is not OnlinePlayerBM player) return;
+
+        if (player.IsTracked)
+        {
+            // Already tracked → open inline analysis dialog
+            ShowPlayerAnalysis(player.BMId, player.Name);
+        }
+        else
+        {
+            TrackingService.TrackPlayer(player.BMId, player.Name, _vm.Selected?.Name ?? "Unknown");
+            player.IsTracked = true;
+            // Refresh list so button text updates
+            RefreshOnlinePlayersList();
+            AppendLog($"[tracking] Now tracking {player.Name} from {_vm.Selected?.Name ?? "this server"}");
+        }
+    }
+
+    private void BtnViewTracking_Click(object sender, RoutedEventArgs e)
+    {
+        ShowTrackedPlayersManager();
+    }
+
+    private void BtnServerBM_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = TrackingService.CurrentServerBMId;
+        if (!string.IsNullOrEmpty(serverId))
+        {
+            OpenUrl($"https://www.battlemetrics.com/servers/rust/{serverId}");
+        }
+    }
+
+    private void BtnPlayerBM_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is OnlinePlayerBM player)
+        {
+            OpenUrl($"https://www.battlemetrics.com/players/{player.BMId}");
+        }
+    }
+
+    private async void BtnAddManual_Click(object sender, RoutedEventArgs e)
+    {
+        var bmId = TxtManualBMId.Text?.Trim();
+        if (string.IsNullOrEmpty(bmId) || !bmId.All(char.IsDigit)) return;
+
+        TxtManualBMId.IsEnabled = false;
+        BtnAddManual.Content = "...";
+        
+        var name = await TrackingService.FetchPlayerNameAsync(bmId);
+        TrackingService.TrackPlayer(bmId, name, _vm.Selected?.Name ?? "Manual Add");
+        
+        TxtManualBMId.Text = "";
+        TxtManualBMId.IsEnabled = true;
+        BtnAddManual.Content = "Track ID";
+        
+        AppendLog($"[tracking] Manually added {name} ({bmId}) to tracking list.");
+        RefreshOnlinePlayersList();
+    }
+
+    private void OpenUrl(string url)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"[error] Failed to open URL: {ex.Message}");
+        }
+    }
+
+    private void ShowTrackedPlayersManager()
+    {
+        var win = new Window
+        {
+            Title = "Managed Tracked Players",
+            Width = 500,
+            Height = 650,
+            Background = new SolidColorBrush(Color.FromRgb(18, 20, 23)),
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Owner = this,
+        };
+
+        var grid = new Grid { Margin = new Thickness(20) };
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // Header
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // Search
+        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // List
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // Actions
+
+        var header = new TextBlock { Text = "Tracked Players", FontSize = 20, FontWeight = FontWeights.Bold, Foreground = Brushes.White, Margin = new Thickness(0,0,0,10) };
+        grid.Children.Add(header);
+
+        var searchBox = new TextBox { 
+            Margin = new Thickness(0,0,0,10), 
+            Padding = new Thickness(6,4,6,4),
+            Background = new SolidColorBrush(Color.FromRgb(30, 32, 35)),
+            Foreground = Brushes.White,
+            BorderBrush = new SolidColorBrush(Color.FromRgb(50, 50, 50)),
+            FontSize = 12
+        };
+        Grid.SetRow(searchBox, 1);
+        grid.Children.Add(searchBox);
+
+        var list = new ListBox { Background = Brushes.Transparent, BorderThickness = new Thickness(0), Foreground = Brushes.White };
+        Grid.SetRow(list, 2);
+        grid.Children.Add(list);
+
+        Action<string> refreshList = null;
+        refreshList = (filter) => {
+            list.Items.Clear();
+            var players = TrackingService.GetTrackedPlayers();
+            if (!string.IsNullOrEmpty(filter)) {
+                players = players.Where(p => 
+                    p.Name.Contains(filter, StringComparison.OrdinalIgnoreCase) || 
+                    p.LastServerName.Contains(filter, StringComparison.OrdinalIgnoreCase)
+                ).ToList();
+            }
+
+            var grouped = players.GroupBy(p => string.IsNullOrEmpty(p.LastServerName) ? "Global / Legacy" : p.LastServerName);
+            foreach(var group in grouped)
+            {
+                list.Items.Add(new TextBlock { 
+                    Text = group.Key, 
+                    FontWeight = FontWeights.Bold, 
+                    Foreground = new SolidColorBrush(Color.FromRgb(88, 166, 255)),
+                    Margin = new Thickness(0, 10, 0, 5),
+                    FontSize = 14
+                });
+
+                foreach(var p in group)
+                {
+                    var pGrid = new Grid { Margin = new Thickness(10,5,0,5) };
+                    pGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    pGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                    pGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                    var nameTxt = new TextBlock { Text = p.Name, VerticalAlignment = VerticalAlignment.Center, FontSize = 13 };
+                    Grid.SetColumn(nameTxt, 0);
+                    pGrid.Children.Add(nameTxt);
+
+                    var viewBtn = new Button { Content = "View", Width = 50, Margin = new Thickness(5,0,0,0), Tag = p.BMId };
+                    viewBtn.Click += (s, e) => ShowTrackingAnalysisWindow((string)((Button)s).Tag);
+                    Grid.SetColumn(viewBtn, 1);
+                    pGrid.Children.Add(viewBtn);
+
+                    var removeBtn = new Button { Content = "Remove", Width = 60, Margin = new Thickness(5,0,0,0), Tag = p.BMId, Background = Brushes.DarkRed, Foreground = Brushes.White };
+                    removeBtn.Click += (s, e) => {
+                        TrackingService.UntrackPlayer((string)((Button)s).Tag);
+                        refreshList(searchBox.Text);
+                    };
+                    Grid.SetColumn(removeBtn, 2);
+                    pGrid.Children.Add(removeBtn);
+
+                    list.Items.Add(pGrid);
+                }
+            }
+            if (players.Count == 0 && !string.IsNullOrEmpty(filter)) {
+                list.Items.Add(new TextBlock { Text = "No results found matching filter.", Margin = new Thickness(0,20,0,0), Foreground = Brushes.Gray, HorizontalAlignment = HorizontalAlignment.Center });
+            }
+        };
+
+        searchBox.TextChanged += (s, e) => refreshList(searchBox.Text);
+        refreshList(""); // Initial load
+
+        var viewAllBtn = new Button { Content = "View All Analysis", Height = 35, Margin = new Thickness(0,15,0,0), Background = new SolidColorBrush(Color.FromRgb(76, 139, 245)), Foreground = Brushes.White };
+        viewAllBtn.Click += (s, e) => ShowTrackingAnalysisWindow();
+        Grid.SetRow(viewAllBtn, 3);
+        grid.Children.Add(viewAllBtn);
+
+        win.Content = grid;
+        win.ShowDialog();
+    }
+
+    private void ShowTrackingAnalysisWindow(string? bmId = null)
+    {
+        var html = TrackingService.GetAnalysisReport(bmId);
+
+        var win = new Window
+        {
+            Title = "Player Activity Analytics & Forecasts",
+            Width = 900,
+            Height = 750,
+            Background = new SolidColorBrush(Color.FromRgb(18, 20, 23)),
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Owner = this,
+        };
+
+        var grid = new Grid();
+        var wv = new WebView2 { Margin = new Thickness(0) };
+        grid.Children.Add(wv);
+        win.Content = grid;
+        
+        win.Loaded += async (s, e) =>
+        {
+            try 
+            {
+                var dataPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "RustPlusDesk", "WebView2_Report");
+                var env = await Microsoft.Web.WebView2.Core.CoreWebView2Environment.CreateAsync(userDataFolder: dataPath);
+                await wv.EnsureCoreWebView2Async(env);
+                wv.NavigateToString(html);
+            } 
+            catch (Exception ex) 
+            {
+                win.Content = new ScrollViewer 
+                { 
+                   Content = new TextBlock 
+                   { 
+                      Text = "Error loading analytics view: " + ex.Message + "\n\nEnsure WebView2 Runtime is installed.", 
+                      Foreground = Brushes.White,
+                      TextWrapping = TextWrapping.Wrap,
+                      Margin = new Thickness(20) 
+                   } 
+                };
+            }
+        };
+
+        win.Show();
+    }
+
+    private void ShowPlayerAnalysis(string bmId, string name)
+    {
+        ShowTrackingAnalysisWindow(bmId);
+    }
 
     private void RebaselineAllAlertRulesFromCurrentShops(IReadOnlyList<RustPlusClientReal.ShopMarker> shops)
     {

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -119,6 +119,13 @@ public static class TrackingService
             _trackedPlayers[bmId].LastServerName = serverName;
         }
         SaveDB();
+
+        // Auto-start tracking if we have a server but no timer yet
+        if (_trackingTimer == null && !string.IsNullOrEmpty(_settings.LastHost))
+        {
+            StartPolling(_settings.LastHost, _settings.LastPort, _settings.LastServerName);
+        }
+        OnOnlinePlayersUpdated?.Invoke();
     }
     
     public static void UntrackPlayer(string bmId)
@@ -126,6 +133,11 @@ public static class TrackingService
         if (_trackedPlayers.Remove(bmId))
         {
             SaveDB();
+            if (_trackedPlayers.Count == 0)
+            {
+                StopPolling();
+            }
+            OnOnlinePlayersUpdated?.Invoke();
         }
     }
     
@@ -392,9 +404,16 @@ public static class TrackingService
         _settings.LastServerName = name;
         SaveDB();
 
-        // Poll every 2 minutes
+        // Poll every 2 minutes only if we have players
         _trackingTimer?.Dispose();
-        _trackingTimer = new Timer(async _ => await PollOnceAsync(), null, 0, 120_000);
+        if (_trackedPlayers.Count > 0)
+        {
+            _trackingTimer = new Timer(async _ => await PollOnceAsync(), null, 0, 120_000);
+        }
+        else
+        {
+            _trackingTimer = null;
+        }
     }
 
     public static void StopPolling()

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -17,6 +17,16 @@ public class TrackedPlayer
     public List<PlayerSession> Sessions { get; set; } = new();
 }
 
+public class TrackingSettings
+{
+    public string LastHost { get; set; } = string.Empty;
+    public int LastPort { get; set; } = 0;
+    public string LastServerName { get; set; } = string.Empty;
+    public bool BackgroundTrackingEnabled { get; set; } = false;
+    public bool CloseToTrayEnabled { get; set; } = false;
+    public bool StartMinimizedEnabled { get; set; } = false;
+}
+
 public class PlayerSession
 {
     public DateTime ConnectTime { get; set; }
@@ -40,11 +50,16 @@ public static class TrackingService
     private static readonly string _dbPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), 
         "RustPlusDesk", "tracked_players.json");
+    private static readonly string _settingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "RustPlusDesk", "tracking_settings.json");
     
     private static Dictionary<string, TrackedPlayer> _trackedPlayers = new();
+    private static TrackingSettings _settings = new();
     private static Timer? _trackingTimer;
     private static string? _lastServerHost;
     private static int _lastServerPort;
+    private static string? _lastServerName;
 
     public static event Action? OnOnlinePlayersUpdated;
     public static string StatusMessage { get; private set; } = "";
@@ -64,10 +79,12 @@ public static class TrackingService
             {
                 var json = File.ReadAllText(_dbPath);
                 var list = JsonSerializer.Deserialize<List<TrackedPlayer>>(json);
-                if (list != null)
-                {
-                    _trackedPlayers = list.ToDictionary(p => p.BMId);
-                }
+                if (list != null) _trackedPlayers = list.ToDictionary(p => p.BMId);
+            }
+            if (File.Exists(_settingsPath))
+            {
+                var json = File.ReadAllText(_settingsPath);
+                _settings = JsonSerializer.Deserialize<TrackingSettings>(json) ?? new();
             }
         }
         catch { }
@@ -78,9 +95,13 @@ public static class TrackingService
         try
         {
             var dir = Path.GetDirectoryName(_dbPath);
-            if (dir != null) Directory.CreateDirectory(dir);
-            var json = JsonSerializer.Serialize(_trackedPlayers.Values.ToList(), new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(_dbPath, json);
+            if (dir != null && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+
+            var jsonP = JsonSerializer.Serialize(_trackedPlayers.Values.ToList(), new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_dbPath, jsonP);
+
+            var jsonS = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_settingsPath, jsonS);
         }
         catch { }
     }
@@ -110,6 +131,26 @@ public static class TrackingService
 
     public static List<TrackedPlayer> GetTrackedPlayers() => _trackedPlayers.Values.ToList();
     public static bool IsTracked(string bmId) => _trackedPlayers.ContainsKey(bmId);
+
+    public static bool IsBackgroundTrackingEnabled
+    {
+        get => _settings.BackgroundTrackingEnabled;
+        set { _settings.BackgroundTrackingEnabled = value; SaveDB(); }
+    }
+
+    public static bool CloseToTrayEnabled
+    {
+        get => _settings.CloseToTrayEnabled;
+        set { _settings.CloseToTrayEnabled = value; SaveDB(); }
+    }
+
+    public static bool StartMinimizedEnabled
+    {
+        get => _settings.StartMinimizedEnabled;
+        set { _settings.StartMinimizedEnabled = value; SaveDB(); }
+    }
+
+    public static (string host, int port, string name) LastServer => (_settings.LastHost, _settings.LastPort, _settings.LastServerName);
 
     public static async Task<string> FetchPlayerNameAsync(string bmId)
     {
@@ -335,7 +376,6 @@ public static class TrackingService
         return sb.ToString();
     }
 
-    private static string? _lastServerName;
     private static string? _foundServerId;
 
     public static void StartPolling(string host, int port, string name)
@@ -344,6 +384,12 @@ public static class TrackingService
         _lastServerPort = port;
         _lastServerName = name;
         _foundServerId = null; // Reset to force new lookup
+
+        _settings.LastHost = host;
+        _settings.LastPort = port;
+        _settings.LastServerName = name;
+        SaveDB();
+
         // Poll every 2 minutes
         _trackingTimer?.Dispose();
         _trackingTimer = new Timer(async _ => await PollOnceAsync(), null, 0, 120_000);

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -64,6 +64,8 @@ public static class TrackingService
     public static event Action? OnOnlinePlayersUpdated;
     public static string StatusMessage { get; private set; } = "";
     public static List<OnlinePlayerBM> LastOnlinePlayers { get; private set; } = new();
+    public static DateTime? LastPullTime { get; private set; }
+    public static bool IsTracking => _trackingTimer != null;
 
     static TrackingService()
     {
@@ -556,6 +558,7 @@ public static class TrackingService
             }
 
             LastOnlinePlayers = onlineList.OrderByDescending(x => x.Duration).ToList();
+            LastPullTime = DateTime.Now;
             OnOnlinePlayersUpdated?.Invoke();
 
             // 3. Update Tracking stats

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -1,0 +1,560 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RustPlusDesk.Services;
+
+public class TrackedPlayer
+{
+    public string BMId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string LastServerName { get; set; } = string.Empty;
+    public List<PlayerSession> Sessions { get; set; } = new();
+}
+
+public class PlayerSession
+{
+    public DateTime ConnectTime { get; set; }
+    public DateTime? DisconnectTime { get; set; }
+}
+
+public class OnlinePlayerBM
+{
+    public string Name { get; set; } = string.Empty;
+    public string BMId { get; set; } = string.Empty;
+    public TimeSpan Duration { get; set; }
+    public bool IsTracked { get; set; }
+    public string PlayTimeStr => Duration.TotalHours >= 1 
+        ? $"{(int)Duration.TotalHours}h {Duration.Minutes}m" 
+        : $"{Duration.Minutes}m";
+}
+
+public static class TrackingService
+{
+    private static readonly HttpClient _http = new();
+    private static readonly string _dbPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), 
+        "RustPlusDesk", "tracked_players.json");
+    
+    private static Dictionary<string, TrackedPlayer> _trackedPlayers = new();
+    private static Timer? _trackingTimer;
+    private static string? _lastServerHost;
+    private static int _lastServerPort;
+
+    public static event Action? OnOnlinePlayersUpdated;
+    public static string StatusMessage { get; private set; } = "";
+    public static List<OnlinePlayerBM> LastOnlinePlayers { get; private set; } = new();
+
+    static TrackingService()
+    {
+        _http.DefaultRequestHeaders.Add("User-Agent", "RustPlusDesk/1.0");
+        LoadDB();
+    }
+
+    private static void LoadDB()
+    {
+        try
+        {
+            if (File.Exists(_dbPath))
+            {
+                var json = File.ReadAllText(_dbPath);
+                var list = JsonSerializer.Deserialize<List<TrackedPlayer>>(json);
+                if (list != null)
+                {
+                    _trackedPlayers = list.ToDictionary(p => p.BMId);
+                }
+            }
+        }
+        catch { }
+    }
+
+    public static void SaveDB()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_dbPath);
+            if (dir != null) Directory.CreateDirectory(dir);
+            var json = JsonSerializer.Serialize(_trackedPlayers.Values.ToList(), new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_dbPath, json);
+        }
+        catch { }
+    }
+
+    public static void TrackPlayer(string bmId, string name, string serverName)
+    {
+        if (!_trackedPlayers.ContainsKey(bmId))
+        {
+            _trackedPlayers[bmId] = new TrackedPlayer { BMId = bmId, Name = name, LastServerName = serverName };
+        }
+        else
+        {
+            _trackedPlayers[bmId].LastServerName = serverName;
+        }
+        SaveDB();
+    }
+    
+    public static void UntrackPlayer(string bmId)
+    {
+        if (_trackedPlayers.Remove(bmId))
+        {
+            SaveDB();
+        }
+    }
+    
+    public static string? CurrentServerBMId => _foundServerId;
+
+    public static List<TrackedPlayer> GetTrackedPlayers() => _trackedPlayers.Values.ToList();
+    public static bool IsTracked(string bmId) => _trackedPlayers.ContainsKey(bmId);
+
+    public static async Task<string> FetchPlayerNameAsync(string bmId)
+    {
+        try
+        {
+            var json = await _http.GetStringAsync($"https://api.battlemetrics.com/players/{bmId}");
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.GetProperty("data").GetProperty("attributes").GetProperty("name").GetString() ?? "Unknown Player";
+        }
+        catch { return "Unknown Player"; }
+    }
+
+    public static void LoadDemoData()
+    {
+        _trackedPlayers.Clear();
+        var now = DateTime.UtcNow;
+
+        // 1. The Night Owl (Plays 00:00 - 06:00)
+        var owl = new TrackedPlayer { BMId = "demo_1", Name = "NightOwl_X" };
+        for (int d = 0; d < 14; d++) {
+            var date = now.Date.AddDays(-d).AddHours(1); // 01:00
+            owl.Sessions.Add(new PlayerSession { ConnectTime = date, DisconnectTime = date.AddHours(4) });
+        }
+        _trackedPlayers[owl.BMId] = owl;
+
+        // 2. The Grinder (Huge playtime, active 12:00 - 02:00)
+        var grinder = new TrackedPlayer { BMId = "demo_2", Name = "IndustrialPvP" };
+        for (int d = 0; d < 7; d++) {
+            var date = now.Date.AddDays(-d).AddHours(12); // Noon
+            grinder.Sessions.Add(new PlayerSession { ConnectTime = date, DisconnectTime = date.AddHours(14) }); // Until 02:00
+        }
+        _trackedPlayers[grinder.BMId] = grinder;
+
+        // 3. The Weekend Warrior (Only Sat/Sun)
+        var weekend = new TrackedPlayer { BMId = "demo_3", Name = "CasualFriday" };
+        for (int d = 0; d < 30; d++) {
+            var date = now.Date.AddDays(-d);
+            if (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday) {
+                weekend.Sessions.Add(new PlayerSession { ConnectTime = date.AddHours(10), DisconnectTime = date.AddHours(18) });
+            }
+        }
+        _trackedPlayers[weekend.BMId] = weekend;
+
+        SaveDB();
+        OnOnlinePlayersUpdated?.Invoke();
+    }
+
+    // Provide tracking analysis view - Rich HTML
+    public static string GetAnalysisReport(string? targetBmId = null)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("<!DOCTYPE html><html><head><meta charset='utf-8'>");
+        sb.AppendLine("<style>");
+        // Root styles
+        sb.AppendLine("body { background: #0d1117; color: #c9d1d9; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; margin: 30px; line-height: 1.5; }");
+        sb.AppendLine(".player-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; margin-bottom: 30px; box-shadow: 0 8px 24px rgba(0,0,0,0.2); }");
+        sb.AppendLine("h1 { color: #f0f6fc; font-size: 28px; font-weight: 600; margin-bottom: 30px; letter-spacing: -0.5px; }");
+
+        // Theme variables (to be overridden per card)
+        sb.AppendLine(".theme-online { --theme-accent: #3fb950; --theme-accent-soft: rgba(63, 185, 80, 0.1); --theme-accent-border: rgba(63, 185, 80, 0.3); --cell-lv1: #0e4429; --cell-lv2: #006d32; --cell-lv3: #26a641; --cell-lv4: #39d353; }");
+        sb.AppendLine(".theme-offline { --theme-accent: #8b949e; --theme-accent-soft: rgba(139, 148, 158, 0.1); --theme-accent-border: rgba(139, 148, 158, 0.3); --cell-lv1: #161b22; --cell-lv2: #21262d; --cell-lv3: #30363d; --cell-lv4: #484f58; }");
+
+        sb.AppendLine("h2 { color: var(--theme-accent); margin: 0 0 16px 0; font-size: 22px; border-bottom: 1px solid #21262d; padding-bottom: 8px; }");
+        sb.AppendLine(".stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px; }");
+        sb.AppendLine(".stat-item { background: #0d1117; padding: 12px; border-radius: 6px; border: 1px solid #21262d; }");
+        sb.AppendLine(".stat-label { font-size: 11px; color: #8b949e; text-transform: uppercase; font-weight: 600; }");
+        sb.AppendLine(".stat-value { font-size: 16px; color: #f0f6fc; font-weight: 600; margin-top: 4px; }");
+        
+        sb.AppendLine(".badge { padding: 4px 10px; border-radius: 4px; font-size: 12px; font-weight: 600; text-transform: uppercase; }");
+        sb.AppendLine(".badge-online { background: rgba(63, 185, 80, 0.1); color: #3fb950; border: 1px solid rgba(63, 185, 80, 0.4); }");
+        sb.AppendLine(".badge-offline { background: rgba(139, 148, 158, 0.05); color: #8b949e; border: 1px solid rgba(139, 148, 158, 0.2); }");
+        
+        sb.AppendLine(".section-title { font-size: 13px; font-weight: 600; color: #8b949e; margin: 25px 0 10px 0; display: flex; align-items: center; }");
+        sb.AppendLine(".section-title::after { content: ''; flex: 1; height: 1px; background: #21262d; margin-left: 10px; }");
+
+        // GitHub style grid
+        sb.AppendLine(".grid-container { display: grid; grid-template-columns: repeat(12, 1fr); gap: 10px; margin-top: 10px; }");
+        sb.AppendLine(".grid-week { display: grid; grid-template-rows: repeat(7, 10px); gap: 2px; }");
+        sb.AppendLine(".grid-cell { width: 10px; height: 10px; border-radius: 2px; background: #21262d; }");
+        sb.AppendLine(".grid-cell.lv1 { background: var(--cell-lv1); }");
+        sb.AppendLine(".grid-cell.lv2 { background: var(--cell-lv2); }");
+        sb.AppendLine(".grid-cell.lv3 { background: var(--cell-lv3); }");
+        sb.AppendLine(".grid-cell.lv4 { background: var(--cell-lv4); }");
+
+        // Hourly heat
+        sb.AppendLine(".hourly-wrap { background: #0d1117; padding: 15px; border-radius: 6px; border: 1px solid #21262d; }");
+        sb.AppendLine(".hourly-container { display: flex; height: 60px; gap: 2px; align-items: flex-end; }");
+        sb.AppendLine(".hour-bar { flex: 1; background: #21262d; border-radius: 2px 2px 0 0; position: relative; }");
+        sb.AppendLine(".hour-bar.active { background: var(--theme-accent); }");
+        sb.AppendLine(".hour-labels { display: flex; justify-content: space-between; margin-top: 8px; font-size: 10px; color: #8b949e; font-family: monospace; }");
+        
+        sb.AppendLine(".insight-box { background: var(--theme-accent-soft); border: 1px solid var(--theme-accent-border); padding: 16px; margin-top: 20px; border-radius: 8px; }");
+        sb.AppendLine(".insight-item { margin: 8px 0; font-size: 14px; display: flex; align-items: center; }");
+        sb.AppendLine(".insight-icon { margin-right: 10px; font-size: 18px; }");
+        sb.AppendLine(".warning { background: rgba(210, 153, 34, 0.1); border: 1px solid rgba(210, 153, 34, 0.2); color: #d29922; padding: 10px; border-radius: 6px; font-size: 12px; margin-top: 15px; }");
+        sb.AppendLine("</style></head><body>");
+
+        sb.AppendLine("<h1>Activity Intelligence Report</h1>");
+        
+        var playersToReport = targetBmId == null 
+            ? _trackedPlayers.Values.ToList() 
+            : _trackedPlayers.Values.Where(p => p.BMId == targetBmId).ToList();
+
+        if (!playersToReport.Any())
+        {
+            sb.AppendLine("<p>No players in tracking database. Start by tracking players from the server list.</p>");
+        }
+
+        var groupedPlayers = playersToReport.GroupBy(p => string.IsNullOrEmpty(p.LastServerName) ? "Global / Legacy" : p.LastServerName);
+
+        foreach(var group in groupedPlayers)
+        {
+            sb.AppendLine($"<div class='section-title' style='color:#58a6ff; font-size:16px; margin-top:40px; border-bottom: 2px solid #30363d;'>{group.Key}</div>");
+            
+            foreach(var p in group)
+            {
+                var totalTime = TimeSpan.Zero;
+                var past7Days = TimeSpan.Zero;
+                var now = DateTime.UtcNow;
+                
+                int[] hourActivity = new int[24];
+                Dictionary<DateTime, int> dailyActivity = new Dictionary<DateTime, int>();
+
+                foreach (var session in p.Sessions)
+                {
+                    var end = session.DisconnectTime ?? now;
+                    var dur = end - session.ConnectTime;
+                    totalTime += dur;
+                    if (session.ConnectTime > now.AddDays(-7)) past7Days += dur;
+
+                    var date = session.ConnectTime.Date;
+                    if (!dailyActivity.ContainsKey(date)) dailyActivity[date] = 0;
+                    dailyActivity[date] += (int)dur.TotalMinutes;
+
+                    var iter = session.ConnectTime;
+                    while (iter < end)
+                    {
+                        hourActivity[iter.ToLocalTime().Hour]++;
+                        iter = iter.AddHours(1);
+                    }
+                }
+
+                double avgSessionMins = p.Sessions.Any() ? totalTime.TotalMinutes / p.Sessions.Count : 0;
+                var isOnline = p.Sessions.Any() && !p.Sessions.Last().DisconnectTime.HasValue;
+                var themeClass = isOnline ? "theme-online" : "theme-offline";
+
+                sb.AppendLine($"<div class='player-card {themeClass}'>");
+                sb.AppendLine($"<h2>{p.Name}</h2>");
+                
+                var statusClass = isOnline ? "badge-online" : "badge-offline";
+                var statusText = isOnline ? "Online" : "Offline";
+                sb.AppendLine($"<div style='margin-bottom:20px;'><span class='badge {statusClass}'>{statusText}</span></div>");
+
+                sb.AppendLine("<div class='stat-grid'>");
+                sb.AppendLine("<div class='stat-item'><div class='stat-label'>Total Tracked Time</div><div class='stat-value'>" + $"{(int)totalTime.TotalHours}h {totalTime.Minutes}m" + "</div></div>");
+                sb.AppendLine("<div class='stat-item'><div class='stat-label'>Last 7 Days</div><div class='stat-value'>" + $"{(int)past7Days.TotalHours}h {past7Days.Minutes}m" + "</div></div>");
+                sb.AppendLine("<div class='stat-item'><div class='stat-label'>Session Count</div><div class='stat-value'>" + p.Sessions.Count + "</div></div>");
+                sb.AppendLine("<div class='stat-item'><div class='stat-label'>Avg Session</div><div class='stat-value'>" + $"{(int)avgSessionMins} min" + "</div></div>");
+                sb.AppendLine("</div>");
+
+            // GitHub Style Grid Section
+            sb.AppendLine("<div class='section-title'>12-WEEK ACTIVITY INTENSITY</div>");
+            sb.AppendLine("<div class='grid-container'>");
+            var startDate = now.Date.AddDays(-83); // 12 weeks
+            for (int w = 0; w < 12; w++)
+            {
+                sb.AppendLine("<div class='grid-week'>");
+                for (int d = 0; d < 7; d++)
+                {
+                    var cur = startDate.AddDays(w * 7 + d);
+                    int mins = dailyActivity.ContainsKey(cur) ? dailyActivity[cur] : 0;
+                    string lv = "";
+                    if (mins > 0) lv = "lv1";
+                    if (mins > 120) lv = "lv2";
+                    if (mins > 300) lv = "lv3";
+                    if (mins > 600) lv = "lv4";
+                    sb.AppendLine($"<div class='grid-cell {lv}' title='{cur:yyyy-MM-dd}: {mins} min'></div>");
+                }
+                sb.AppendLine("</div>");
+            }
+            sb.AppendLine("</div>");
+
+            // 24h Heatmap Section
+            sb.AppendLine("<div class='section-title'>24H ACTIVITY FORECAST</div>");
+            sb.AppendLine("<div class='hourly-wrap'>");
+            sb.AppendLine("<div class='hourly-container'>");
+            int maxH = hourActivity.Any() ? hourActivity.Max() : 0;
+            for(int i=0; i<24; i++)
+            {
+                double hVal = maxH > 0 ? (double)hourActivity[i] / maxH * 100 : 5;
+                string activeClass = hourActivity[i] > (maxH * 0.4) ? "active" : "";
+                sb.AppendLine($"<div class='hour-bar {activeClass}' style='height:{hVal}%' title='{i:00}:00 - {hourActivity[i]} occurrences'></div>");
+            }
+            sb.AppendLine("</div>");
+            sb.AppendLine("<div class='hour-labels'>");
+            sb.AppendLine("<span>00:00</span><span>04:00</span><span>08:00</span><span>12:00</span><span>16:00</span><span>20:00</span><span>23:00</span>");
+            sb.AppendLine("</div>");
+            sb.AppendLine("</div>");
+
+            // AI Insights Box
+            int peakPlay = 0; int maxPlayVal = -1;
+            int peakSleep = 0; int minPlayVal = int.MaxValue;
+            for(int i=0; i<24; i++) {
+                if (hourActivity[i] > maxPlayVal) { maxPlayVal = hourActivity[i]; peakPlay = i; }
+                if (hourActivity[i] < minPlayVal) { minPlayVal = hourActivity[i]; peakSleep = i; }
+            }
+
+            sb.AppendLine("<div class='insight-box'>");
+            sb.AppendLine("<div class='insight-item'><span class='insight-icon'>⚡</span> Most likely to play: <b>" + $"{peakPlay:00}:00 - {(peakPlay + 3) % 24:00}:00" + "</b></div>");
+            sb.AppendLine("<div class='insight-item'><span class='insight-icon'>💤</span> Most likely to sleep: <b>" + $"{peakSleep:00}:00 - {(peakSleep + 5) % 24:00}:00" + "</b></div>");
+            if (p.Sessions.Count < 5) {
+                sb.AppendLine("<div class='warning'><b>Data Confidence: LOW</b><br/>More sessions needed for accurate pattern recognition. Predictions currenty represent early observations.</div>");
+            } else {
+                sb.AppendLine("<div style='color: #8b949e; font-size: 11px; margin-top: 10px;'>Forecast based on " + p.Sessions.Count + " recorded sessions.</div>");
+            }
+            sb.AppendLine("</div>");
+
+            sb.AppendLine("</div>");
+        }
+    }
+        
+        sb.AppendLine("</body></html>");
+        return sb.ToString();
+    }
+
+    private static string? _lastServerName;
+    private static string? _foundServerId;
+
+    public static void StartPolling(string host, int port, string name)
+    {
+        _lastServerHost = host;
+        _lastServerPort = port;
+        _lastServerName = name;
+        _foundServerId = null; // Reset to force new lookup
+        // Poll every 2 minutes
+        _trackingTimer?.Dispose();
+        _trackingTimer = new Timer(async _ => await PollOnceAsync(), null, 0, 120_000);
+    }
+
+    public static void StopPolling()
+    {
+        _trackingTimer?.Dispose();
+        _trackingTimer = null;
+    }
+
+    public static async Task FetchOnlinePlayersNowAsync()
+    {
+        await PollOnceAsync();
+    }
+
+    private static async Task PollOnceAsync()
+    {
+        if (string.IsNullOrEmpty(_lastServerHost)) return;
+
+        try
+        {
+            // 1. Get BM Server ID
+            if (string.IsNullOrEmpty(_foundServerId))
+            {
+                StatusMessage = "Looking up server...";
+
+                // Strategy 1: Filter by exact address and port
+                var searchUrlAddr = $"https://api.battlemetrics.com/servers?filter[address]={Uri.EscapeDataString(_lastServerHost)}&filter[port]={_lastServerPort}&filter[game]=rust";
+                
+                using var responseAddr = await _http.GetAsync(searchUrlAddr);
+                if (responseAddr.IsSuccessStatusCode)
+                {
+                    var resAddr = await responseAddr.Content.ReadAsStringAsync();
+                    using var docAddr = JsonDocument.Parse(resAddr);
+                    var dataArr = docAddr.RootElement.GetProperty("data");
+                    if (dataArr.GetArrayLength() > 0)
+                    {
+                        _foundServerId = dataArr[0].GetProperty("id").GetString();
+                    }
+                }
+
+                // Strategy 2: Search by IP:PORT directly (Recommended Method 2)
+                if (string.IsNullOrEmpty(_foundServerId))
+                {
+                    var query = $"{_lastServerHost}:{_lastServerPort}";
+                    var searchUrl = $"https://api.battlemetrics.com/servers?filter[game]=rust&filter[search]={Uri.EscapeDataString(query)}";
+                    
+                    using var response = await _http.GetAsync(searchUrl);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var json = await response.Content.ReadAsStringAsync();
+                        using var doc = JsonDocument.Parse(json);
+                        var dataArr = doc.RootElement.GetProperty("data");
+                        if (dataArr.GetArrayLength() > 0)
+                        {
+                            _foundServerId = dataArr[0].GetProperty("id").GetString();
+                        }
+                    }
+                }
+
+                // Strategy 3: If still failed, search by name and verify IP
+                if (string.IsNullOrEmpty(_foundServerId) && !string.IsNullOrEmpty(_lastServerName))
+                {
+                    var searchUrlName = $"https://api.battlemetrics.com/servers?filter[game]=rust&filter[search]={Uri.EscapeDataString(_lastServerName)}";
+                    using var responseName = await _http.GetAsync(searchUrlName);
+                    if (responseName.IsSuccessStatusCode)
+                    {
+                        var resName = await responseName.Content.ReadAsStringAsync();
+                        using var docName = JsonDocument.Parse(resName);
+                        var dataArr = docName.RootElement.GetProperty("data");
+
+                        foreach (var serverObj in dataArr.EnumerateArray())
+                        {
+                            var attr = serverObj.GetProperty("attributes");
+                            var ip = attr.TryGetProperty("ip", out var vIp) ? vIp.GetString() : "";
+                            var port = attr.TryGetProperty("port", out var vPort) ? vPort.GetInt32() : 0;
+                            var qPort = attr.TryGetProperty("portQuery", out var vQPort) ? vQPort.GetInt32() : 0;
+
+                            if (ip == _lastServerHost && (port == _lastServerPort || qPort == _lastServerPort))
+                            {
+                                _foundServerId = serverObj.GetProperty("id").GetString();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(_foundServerId))
+            {
+                StatusMessage = $"Server not found on Battlemetrics ({_lastServerHost}:{_lastServerPort})";
+                OnOnlinePlayersUpdated?.Invoke();
+                return;
+            }
+
+            // 2. Get Players using the ID we found
+            StatusMessage = "Fetching players...";
+            var reqUrl = $"https://api.battlemetrics.com/servers/{_foundServerId}?include=player";
+            using var responsePlayers = await _http.GetAsync(reqUrl);
+            if (!responsePlayers.IsSuccessStatusCode)
+            {
+                StatusMessage = $"Fetch Error: {(int)responsePlayers.StatusCode} {responsePlayers.ReasonPhrase}";
+                OnOnlinePlayersUpdated?.Invoke();
+                return;
+            }
+
+            var pRes = await responsePlayers.Content.ReadAsStringAsync();
+            using var pDoc = JsonDocument.Parse(pRes);
+            
+            var onlineList = new List<OnlinePlayerBM>();
+            var newOnlineIds = new HashSet<string>();
+
+            if (pDoc.RootElement.TryGetProperty("included", out var included))
+            {
+                foreach (var inc in included.EnumerateArray())
+                {
+                    if (inc.GetProperty("type").GetString() == "player")
+                    {
+                        var bmId = inc.GetProperty("id").GetString() ?? "";
+                        var name = inc.GetProperty("attributes").GetProperty("name").GetString() ?? "Unknown";
+                        int seconds = 0;
+                        if (inc.TryGetProperty("meta", out var meta))
+                        {
+                            // Playtime is often in a metadata array as 'time' key
+                            if (meta.TryGetProperty("metadata", out var metaArr) && metaArr.ValueKind == JsonValueKind.Array)
+                            {
+                                foreach (var mObj in metaArr.EnumerateArray())
+                                {
+                                    if (mObj.TryGetProperty("key", out var k) && k.GetString() == "time" && 
+                                        mObj.TryGetProperty("value", out var v))
+                                    {
+                                        seconds = v.ValueKind == JsonValueKind.Number ? v.GetInt32() : 0;
+                                        break;
+                                    }
+                                }
+                            }
+                            // Fallback to direct 'time' property if present
+                            else if (meta.TryGetProperty("time", out var timeProp))
+                            {
+                                seconds = timeProp.GetInt32();
+                            }
+                        }
+                        
+                        onlineList.Add(new OnlinePlayerBM
+                        {
+                            BMId = bmId,
+                            Name = name,
+                            Duration = TimeSpan.FromSeconds(seconds),
+                            IsTracked = _trackedPlayers.ContainsKey(bmId)
+                        });
+                        newOnlineIds.Add(bmId);
+                    }
+                }
+            }
+
+            if (onlineList.Count == 0)
+            {
+                StatusMessage = "No online players found on Battlemetrics.";
+            }
+            else
+            {
+                StatusMessage = "";
+            }
+
+            LastOnlinePlayers = onlineList.OrderByDescending(x => x.Duration).ToList();
+            OnOnlinePlayersUpdated?.Invoke();
+
+            // 3. Update Tracking stats
+            UpdateTrackingStats(newOnlineIds);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Connection Error: {ex.Message}";
+            OnOnlinePlayersUpdated?.Invoke();
+        }
+    }
+
+    private static void UpdateTrackingStats(HashSet<string> currentlyOnlineIds)
+    {
+        bool changed = false;
+        var now = DateTime.UtcNow;
+
+        foreach (var tp in _trackedPlayers.Values)
+        {
+            bool isOnline = currentlyOnlineIds.Contains(tp.BMId);
+            var lastSession = tp.Sessions.LastOrDefault();
+
+            if (isOnline)
+            {
+                if (lastSession == null || lastSession.DisconnectTime.HasValue)
+                {
+                    // Newly connected
+                    tp.Sessions.Add(new PlayerSession { ConnectTime = now, DisconnectTime = null });
+                    changed = true;
+                }
+            }
+            else
+            {
+                if (lastSession != null && !lastSession.DisconnectTime.HasValue)
+                {
+                    // Newly disconnected
+                    lastSession.DisconnectTime = now;
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed)
+        {
+            SaveDB();
+        }
+    }
+}

--- a/RustPlusDesktop/ViewModel.cs
+++ b/RustPlusDesktop/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿using RustPlusDesk.Models;
+using RustPlusDesk.Models;
 using RustPlusDesk.Services;
 using RustPlusDesk.Views;
 using System;
@@ -23,6 +23,13 @@ public class MainViewModel : INotifyPropertyChanged
     }
 
     public bool CanStartPairing => !_isPairingRunning && !IsBusy;
+
+    private bool _isTrackingActive;
+    public bool IsTrackingActive
+    {
+        get => _isTrackingActive;
+        set { _isTrackingActive = value; OnPropertyChanged(); }
+    }
 
     public bool IsBusy
     {


### PR DESCRIPTION
### Advanced Activity Intelligence & Tracking Update

**_If you need any help merging code to your repo codebase contact me down here!_**

Introduced a comprehensive player intelligence system that leverages Battlemetrics data to provide deep insights into player behavior and server activity.

- Player Tracking System : Automated session monitoring that tracks player connections and disconnections to build a historical activity database.
- Activity Intensity Grid : A 12-week GitHub-style heatmap that visualizes player engagement and consistency over time.
- 24-Hour Activity Forecast : An hourly heatmap and predictive model that identifies peak activity windows and potential "off-hours" for targeted gameplay.
- AI-Driven Insights : Automated analysis of tracked data to predict most likely play and sleep schedules, including data confidence indicators.
- Performance Metrics : Detailed tracking of total time played, 7-day activity trends, session counts, and average session durations.
### Background Operations & System Tray Integration
Enhanced the application's reliability and user experience by enabling continuous background monitoring without requiring the main window to remain open.

- Minimize to Tray : Added system tray integration with a context menu, allowing the app to reside in the notification area for a cleaner workspace.
- Continuous Background Tracking : Implemented a persistent tracking mode that ensures player data collection continues even when the UI is closed.
- Startup Integration : Added an option to automatically launch the application with Windows (minimized to tray) to ensure tracking is always active.
- Single Instance Management : Integrated named pipe communication to ensure only one instance of the app runs at a time, automatically bringing the existing instance to the foreground when launched again.
- Persistence & Settings : Added support for saving tracking preferences, including "Close to Tray" and "Start Minimized" configurations.

> 
> `minimization to tray icon `
> 
> <img width="179" height="76" alt="image" src="https://github.com/user-attachments/assets/18bb095f-74f2-4bfd-bba2-ce520dbf00c0" />

> `New online players list from battlematrics (still working on playtime fix showing 0 min) `
> **BM** button open the player's battlematrics profile 
> 
> <img width="481" height="348" alt="image" src="https://github.com/user-attachments/assets/1aef016a-8290-4200-aa5a-7f1c46fb0bae" />


> `Tracked Players List with background tracking options and minimize to tray icon`
> 
> 
> <img width="477" height="637" alt="image" src="https://github.com/user-attachments/assets/589b2b7a-0087-494c-b429-57f03497a0d4" />


> `tracking report  example (per player or all players) - I will update image later when more data is collected by app`
> 
> 
> <img width="878" height="1120" alt="image" src="https://github.com/user-attachments/assets/521a3401-9896-4c39-9f99-c9789d129bc6" />

UPDATE______________________
feat: add visual tracking status indicator and tray updates

- Add IsTrackingActive property to ViewModel for UI binding
- Expose LastPullTime and IsTracking properties in TrackingService
- Update main window to display tracking status with pulsing indicator
- Show last pull time in UI and tray menu
- Modify tray menu to show dynamic tracking status and last update time
- Fix auto-start condition to respect minimized setting
<img width="639" height="192" alt="image" src="https://github.com/user-attachments/assets/56267627-42bb-4438-ba6b-a2882384d1af" />
and in tray icon also 
<img width="216" height="136" alt="image" src="https://github.com/user-attachments/assets/cc8c212b-b6d0-4ccf-b568-421f2832881a" />

UPDATE__2______
fix(tracking): prevent polling with no tracked players and update UI accordingly

- Auto-start tracking only when server is configured and timer isn't running
- Stop polling when last player is removed from tracking
- Update UI to show appropriate status messages when no players are tracked
- Display "--:--" for last pull time when no players are tracked
