### PR TITLE
- The Tracking & Quality of Life Update - The Settings & Session Accuracy Update - BattleMetrics Integration & UI Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ installer/Output/*
 !RustPlusDesktop/*.png
 !RustPlusDesktop/*.jpg
 RustPlusDesktop/RustPlusDesk_lbvqmzga_wpftmp.csproj
-# RustPlusDesktop/Setup.iss
+RustPlusDesktop/Setup.iss

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ installer/Output/*
 !RustPlusDesktop/*.png
 !RustPlusDesktop/*.jpg
 RustPlusDesktop/RustPlusDesk_lbvqmzga_wpftmp.csproj
-RustPlusDesktop/Setup.iss
+# RustPlusDesktop/Setup.iss

--- a/RustPlusDesktop/App.xaml.cs
+++ b/RustPlusDesktop/App.xaml.cs
@@ -24,6 +24,9 @@ public partial class App : Application
     private MainWindow? _main;
     private System.Windows.Forms.NotifyIcon? _trayIcon;
 
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
@@ -120,7 +123,26 @@ public partial class App : Application
             });
         };
 
-        _trayIcon.ContextMenuStrip = menu;
+        _trayIcon.MouseUp += (s, e) =>
+        {
+            if (e.Button == System.Windows.Forms.MouseButtons.Right)
+            {
+                // Ensure the window exists to provide a handle for focus management
+                if (_main == null)
+                {
+                    _main = new MainWindow();
+                    _main.Closed += (s, ev) => _main = null;
+                }
+
+                // This is a known fix for NotifyIcon context menus in WPF.
+                // It ensures the menu opens on the first click and closes when clicking away.
+                var handle = new System.Windows.Interop.WindowInteropHelper(_main).Handle;
+                SetForegroundWindow(handle);
+
+                menu.Show(System.Windows.Forms.Control.MousePosition);
+            }
+        };
+
         _trayIcon.DoubleClick += (s, e) => ShowMainWindow();
         
         // Also update tray tooltip periodically or on event

--- a/RustPlusDesktop/MainWindow.xaml
+++ b/RustPlusDesktop/MainWindow.xaml
@@ -1140,23 +1140,34 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                                         <StackPanel Margin="0,2,0,0">
 
                                             <!-- ===== Zeile ===== -->
+                                            <Border CornerRadius="10" Padding="14,12" Margin="0,4,8,4">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="#171A21"/>
+                                                        <Setter Property="BorderBrush" Value="#222734"/>
+                                                        <Setter Property="BorderThickness" Value="1"/>
+                                                        <Style.Triggers>
+                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter Property="Background" Value="#1C202A"/>
+                                                                <Setter Property="BorderBrush" Value="#303746"/>
+                                                            </Trigger>
+                                                            <DataTrigger Binding="{Binding IsMissing}" Value="True">
+                                                                <Setter Property="Opacity" Value="0.6"/>
+                                                                <Setter Property="Background" Value="#101217"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding IsGroup}" Value="True">
+                                                                <Setter Property="Background" Value="#141F33"/>
+                                                                <Setter Property="BorderBrush" Value="#253550"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ColTypeID"/>
                                                     <ColumnDefinition Width="*"    SharedSizeGroup="ColAlias"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ColToggle"/>
                                                 </Grid.ColumnDefinitions>
-
-                                                <Grid.Style>
-                                                    <Style TargetType="Grid">
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsMissing}" Value="True">
-                                                                <Setter Property="Opacity" Value="0.6"/>
-
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Grid.Style>
 
                                                 <!-- Spalte 1: Display -->
                                                 <!-- Spalte 1: Icon + (#id) [state] für bekannte Kinds; sonst: alter Display-Text -->
@@ -1367,8 +1378,7 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                                                 <!-- Spalte 2: Alias -->
                                                 <TextBlock Grid.Column="1"
                          VerticalAlignment="Center"
-                         ToolTip="Right click to rename"
-                                                           Foreground="#4FC3F7">
+                         ToolTip="Right click to rename" FontSize="14" FontWeight="SemiBold" Margin="16,0,0,0" Foreground="#EAECEE">
                                                     <TextBlock.Text>
                                                         <Binding Path="Alias" TargetNullValue="(no custom name)"/>
                                                     </TextBlock.Text>
@@ -1603,6 +1613,7 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                                                 </Border>
 
                                             </Grid>
+                                            </Border>
                                             <!-- ===== Ende Zeile ===== -->
 
                                             <!-- ===== Klappbereich (hängt direkt an 
@@ -1670,8 +1681,14 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                                         </Style.Triggers>
                                     </Style>
                                 </StackPanel.Style>
-                                <TextBlock Text="No devices found" Foreground="{StaticResource TextSubtle}" HorizontalAlignment="Center" FontStyle="Italic"/>
-                                <TextBlock Text="Pair a device to see it here" Foreground="{StaticResource TextSubtle}" FontSize="10" HorizontalAlignment="Center" Opacity="0.6"/>
+                                
+                                <Border Background="#101217" BorderBrush="#1C202A" BorderThickness="1" CornerRadius="16" Padding="32,24" HorizontalAlignment="Center">
+                                    <StackPanel>
+                                        <TextBlock Text="📡" FontSize="36" HorizontalAlignment="Center" Margin="0,0,0,12" Opacity="0.8"/>
+                                        <TextBlock Text="No devices found" Foreground="#EAECEE" FontSize="16" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                                        <TextBlock Text="Pair a smart device, switch or alarm to see it here" Foreground="#7F8A96" FontSize="12" HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="200" TextAlignment="Center"/>
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
 
 

--- a/RustPlusDesktop/MainWindow.xaml
+++ b/RustPlusDesktop/MainWindow.xaml
@@ -668,6 +668,7 @@
         </Style>
 
         <conv:BoolToVisibilityConverter x:Key="BoolToVisibility"/>
+        <conv:BoolToVisibilityConverter x:Key="BoolToVisibilityInv" Invert="True"/>
         <conv:NotNullToBoolConverter   x:Key="NotNull"/>
 
     </Window.Resources>
@@ -722,6 +723,12 @@
                 BorderBrush="{DynamicResource CardBorder}"
                 Margin="8,0,0,0"
                 ToolTip="Show latest changes"/>
+                                    <Button x:Name="BtnSettings" 
+                Content=" ⚙ Settings " 
+                Click="BtnSettings_Click"
+                Style="{StaticResource GhostButton}"
+                Margin="8,0,0,0"
+                ToolTip="App Settings &amp; Options"/>
                                 </StackPanel>
                             </Grid>
                         </Grid>
@@ -752,41 +759,142 @@
 
                     <Separator Margin="0,8,0,8"/>
 
-                    <TextBlock Text="Server" Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,0,0,8"/>
-                    <ListBox x:Name="ListServers"
-                     ItemsSource="{Binding Servers}"
-                     SelectedItem="{Binding Selected, Mode=TwoWay}"
-                     DisplayMemberPath="Name"
-                     Foreground="White"
-                     MinHeight="70"
-                     MaxHeight="110"
-                     SelectionChanged="ListServers_SelectionChanged">
+                    <TextBlock Text="Paired servers list" Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,0,0,8"/>
+                    <Grid x:Name="ServerListGrid">
+                        <ListBox x:Name="ListServers"
+                          ItemsSource="{Binding Servers}"
+                          SelectedItem="{Binding Selected, Mode=TwoWay}"
+                          DisplayMemberPath="Name"
+                          Foreground="White"
+                          MinHeight="70"
+                          MaxHeight="110"
+                          SelectionChanged="ListServers_SelectionChanged">
 
-                        <ListBox.Resources>
-                            <ContextMenu x:Key="ServerCtx" Foreground="White" Style="{StaticResource DarkContextMenu}">
-                                <!-- Der Trick: den aktuellen Server ins Tag binden -->
-                                <MenuItem Header="Server löschen…"
-                                  Foreground="Black"
-                                  Click="Server_Delete_Click"
-                                  Tag="{Binding PlacementTarget.DataContext,
-                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                            </ContextMenu>
-                        </ListBox.Resources>
+                            <ListBox.Resources>
+                                <ContextMenu x:Key="ServerCtx" Foreground="White" Style="{StaticResource DarkContextMenu}">
+                                    <!-- Der Trick: den aktuellen Server ins Tag binden -->
+                                    <MenuItem Header="Server löschen…"
+                                      Foreground="Black"
+                                      Click="Server_Delete_Click"
+                                      Tag="{Binding PlacementTarget.DataContext,
+                                            RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                </ContextMenu>
+                            </ListBox.Resources>
 
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="ContextMenu" Value="{StaticResource ServerCtx}"/>
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="ContextMenu" Value="{StaticResource ServerCtx}"/>
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                        </ListBox>
+
+                        <TextBlock Text="No servers paired yet" 
+                                   Foreground="{StaticResource TextSubtle}" 
+                                   FontStyle="Italic"
+                                   FontSize="12"
+                                   HorizontalAlignment="Center" 
+                                   VerticalAlignment="Center"
+                                   IsHitTestVisible="False">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Servers.Count}" Value="0">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Grid>
+
+                    <!-- Connection Card -->
+                    <Border Background="{StaticResource SurfaceAlt}" Margin="0,8,0,0">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource Card}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Selected, Converter={StaticResource NotNull}}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
                             </Style>
-                        </ListBox.ItemContainerStyle>
-                    </ListBox>
+                        </Border.Style>
+                        <StackPanel>
+                            <DockPanel Margin="0,0,0,5">
+                                <TextBlock Text="{Binding Selected.Name, FallbackValue='Select a Server'}" 
+                                           Foreground="White" FontWeight="Bold" FontSize="18"
+                                           VerticalAlignment="Center"/>
+                                <Button Content="ⓘ Info" 
+                                        Click="BtnShowServerInfo_Click" 
+                                        HorizontalAlignment="Right" 
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource GhostButton}" 
+                                        FontSize="11" 
+                                        Padding="6,2"
+                                        Foreground="{StaticResource TextSubtle}"
+                                        ToolTip="Show Server Description"/>
+                            </DockPanel>
 
-                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                            <Separator Background="{StaticResource CardBorder}" Margin="0,4,0,8"/>
+
+                            <DockPanel LastChildFill="False">
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                                    <Ellipse Width="12" Height="12" Margin="0,0,10,0">
+                                        <Ellipse.Style>
+                                            <Style TargetType="Ellipse">
+                                                <Setter Property="Fill" Value="#EF5350"/> <!-- Disconnected: Red -->
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                                        <Setter Property="Fill" Value="#FFCA28"/> <!-- Pairing/Connecting: Yellow -->
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Selected.IsConnected}" Value="True">
+                                                        <Setter Property="Fill" Value="#66BB6A"/> <!-- Connected: Green -->
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Ellipse.Style>
+                                    </Ellipse>
+                                    <TextBlock FontWeight="Bold" FontSize="13" VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="DISCONNECTED"/>
+                                                <Setter Property="Foreground" Value="#EF5350"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                                        <Setter Property="Text" Value="PAIRING..."/>
+                                                        <Setter Property="Foreground" Value="#FFCA28"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Selected.IsConnected}" Value="True">
+                                                        <Setter Property="Text" Value="CONNECTED"/>
+                                                        <Setter Property="Foreground" Value="#66BB6A"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                    <Button Content=" Connect to Server " Click="BtnConnect_Click" 
+                                            Style="{StaticResource PrimaryButton}" 
+                                            Visibility="{Binding Selected.IsConnected, Converter={StaticResource BoolToVisibilityInv}}"/>
+                                    <Button Content=" Disconnect " Click="BtnDisconnect_Click" 
+                                            Background="#D32F2F" BorderBrush="#B71C1C" Foreground="White"
+                                            Visibility="{Binding Selected.IsConnected, Converter={StaticResource BoolToVisibility}}"/>
+                                </StackPanel>
+                            </DockPanel>
+                        </StackPanel>
+                    </Border>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
                         <Button x:Name="BtnListenPairing"
-        Content="Listen (Pairing)"
-        Width="150"
-        Click="BtnListenPairing_Click"
-        IsEnabled="{Binding CanStartPairing}"
-        Margin="0,0,8,0">
+                                Content="Listen (Pairing)"
+                                Width="120"
+                                Style="{StaticResource GhostButton}"
+                                Click="BtnListenPairing_Click"
+                                IsEnabled="{Binding CanStartPairing}"
+                                Margin="0,0,8,0">
                             <Button.ContextMenu>
                                 <ContextMenu Style="{StaticResource DarkContextMenu}">
                                     <MenuItem Header="Try Pairing with Edge" Click="BtnListenWithEdge_Click"/>
@@ -797,18 +905,14 @@
                                 </ContextMenu>
                             </Button.ContextMenu>
                         </Button>
-                        <TextBlock x:Name="TxtPairingState" VerticalAlignment="Center" Text="Pairing: idle" Margin="0,0,30,0"/>
+                        <TextBlock x:Name="TxtPairingState" VerticalAlignment="Center" Text="Pairing: idle" Foreground="{StaticResource TextSubtle}" FontSize="11" Margin="0,0,30,0"/>
 
-                        <Button Content="Connect"
-                        Width="100"
-                        Click="BtnConnect_Click"
-                        Margin="0,0,8,0"
-                        Background="{DynamicResource AccentDark}" BorderBrush="{DynamicResource Accent}"/>
+                        <TextBlock Text="Tip: Right-click Listen for more options" 
+                                   Foreground="{StaticResource TextSubtle}" 
+                                   FontSize="9" VerticalAlignment="Center" FontStyle="Italic"/>
                     </StackPanel>
 
-                    <TextBlock Margin="0,8,0,0"
-                       Text="Click Listen (Pairing) to pair new servers. Rightclick for more options." 
-                       FontSize="9.5" FontStyle="Italic"/>
+                    <Separator Margin="0,12,0,12"/>
 
                     <Grid Margin="0,4,0,0">
                         <Grid.ColumnDefinitions>
@@ -954,7 +1058,7 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                                             </DataTemplate>
                                         </ListBox.ItemTemplate>
                                     </ListBox>
-                                    <Button x:Name="BtnViewTracking" Grid.Row="3" Content="View Tracking Analysis" Margin="0,6,0,0" Style="{StaticResource PrimaryButton}" Click="BtnViewTracking_Click" />
+                                    <Button x:Name="BtnViewTracking" Grid.Row="3" Content="View tracker players list" Margin="0,6,0,0" Style="{StaticResource PrimaryButton}" Click="BtnViewTracking_Click" />
                                 </Grid>
                             </Border>
                         </Popup>
@@ -969,26 +1073,39 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                 <!-- CENTER: TabControl füllt den Rest, mit Mindesthöhe -->
                 <TabControl x:Name="MainTabs"
                     Style="{StaticResource PrettyTabControl}"
-                    MinHeight="350"
                     VerticalAlignment="Stretch">
                     <!-- ===== DEVICES ===== -->
                     <TabItem Header="Devices" Style="{StaticResource PrettyTabItem}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                        <DockPanel LastChildFill="True">
+                            <!-- Footer -->
+                            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                                <Button x:Name="BtnHotkeys" Content="Hotkeys" Width="90" Style="{StaticResource GhostButton}" Click="BtnHotkeys_Click" Margin="0,0,10,0"/>
+                                <Button x:Name="BtnDevicesImport"
+                                        Width="32" Height="32" Margin="0,0,8,0" Padding="4" 
+                                        Style="{StaticResource GhostButton}" ToolTip="Import devices from teammates" Click="BtnDevicesImport_Click">
+                                    <Image Source="pack://application:,,,/icons/cloud-download.png" Width="24"/>
+                                </Button>
+                                <Button x:Name="BtnDevicesExport"
+                                        Width="32" Height="32" Margin="0,0,16,0" Padding="4" 
+                                        Style="{StaticResource GhostButton}" ToolTip="Export devices to teammates" Click="BtnDevicesExport_Click">
+                                    <Image Source="pack://application:,,,/icons/cloud-upload.png" Width="24"/>
+                                </Button>
+                                <Button Content="Refresh" Width="80" Margin="10,0,0,0" Style="{StaticResource GhostButton}" Click="BtnDeviceRefresh_Click"/>
+                                <Button Content="Delete" Width="80" Margin="10,0,0,0" Style="{StaticResource GhostButton}" Click="BtnDeleteDevice_Click"
+                                        ToolTip="You can only delete missing devices"
+                                        IsEnabled="{Binding ElementName=ListDevices, Path=SelectedItem.IsMissing, Converter={StaticResource NotNull}}"/>
+                            </StackPanel>
 
-                            <TreeView x:Name="ListDevices" Grid.IsSharedSizeScope="True"
-             Grid.Row="0"
-             ItemsSource="{Binding CurrentDevices}"
-             SelectedItemChanged="ListDevices_SelectedItemChanged"
-             ScrollViewer.CanContentScroll="False"
-             VirtualizingPanel.IsVirtualizing="False"
-             VirtualizingPanel.ScrollUnit="Pixel"
-             HorizontalContentAlignment="Stretch"
-             Background="Transparent"
-             BorderThickness="0">
+                            <Grid>
+                                <TreeView x:Name="ListDevices" Grid.IsSharedSizeScope="True"
+                                          ItemsSource="{Binding CurrentDevices}"
+                                          SelectedItemChanged="ListDevices_SelectedItemChanged"
+                                          ScrollViewer.CanContentScroll="False"
+                                          VirtualizingPanel.IsVirtualizing="False"
+                                          VirtualizingPanel.ScrollUnit="Pixel"
+                                          HorizontalContentAlignment="Stretch"
+                                          Background="Transparent"
+                                          BorderThickness="0">
 
                                 <TreeView.ItemContainerStyle>
                                     <Style TargetType="TreeViewItem">
@@ -1533,41 +1650,25 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
                                     </HierarchicalDataTemplate>
                                 </TreeView.ItemTemplate>
                             </TreeView>
-
-                            <!-- Footer -->
-                            <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-                                <Button x:Name="BtnHotkeys" Content="Hotkeys" Width="90" Style="{StaticResource GhostButton}" Click="BtnHotkeys_Click" Margin="0,0,10,0"/>
-                                <!--  <Button Content="Info" Width="80" Style="{StaticResource GhostButton}" Click="BtnDeviceInfo_Click" 
-              IsEnabled="{Binding ElementName=ListDevices, Path=SelectedItem, Converter={StaticResource NotNull}}"/> -->
-                                <!-- Import Devices (Cloud-Download) -->
-                                <Button x:Name="BtnDevicesImport"
-            Width="32"
-            Height="32"
-            Margin="0,0,8,0"
-            Padding="4" 
-            Style="{StaticResource GhostButton}"
-            ToolTip="Import devices from teammates"
-            Click="BtnDevicesImport_Click">
-                                    <Image Source="pack://application:,,,/icons/cloud-download.png" Width="24"/>
-                                </Button>
-
-                                <!-- Export Devices (Cloud-Upload) -->
-                                <Button x:Name="BtnDevicesExport"
-            Width="32"
-            Height="32"
-            Margin="0,0,16,0"
-                                        Padding="4" 
-            Style="{StaticResource GhostButton}"
-            ToolTip="Export devices to teammates"
-            Click="BtnDevicesExport_Click">
-                                    <Image Source="pack://application:,,,/icons/cloud-upload.png" Width="24"/>
-                                </Button>
-                                <Button Content="Refresh" Width="80" Margin="10,0,0,0" Style="{StaticResource GhostButton}" Click="BtnDeviceRefresh_Click"/>
-                                <Button Content="Delete" Width="80" Margin="10,0,0,0" Style="{StaticResource GhostButton}" Click="BtnDeleteDevice_Click"
-              ToolTip="You can only delete missing devices"
-              IsEnabled="{Binding ElementName=ListDevices, Path=SelectedItem.IsMissing, Converter={StaticResource NotNull}}"/>
+                            
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasItems, ElementName=ListDevices}" Value="False">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Text="No devices found" Foreground="{StaticResource TextSubtle}" HorizontalAlignment="Center" FontStyle="Italic"/>
+                                <TextBlock Text="Pair a device to see it here" Foreground="{StaticResource TextSubtle}" FontSize="10" HorizontalAlignment="Center" Opacity="0.6"/>
                             </StackPanel>
-                        </Grid>
+
+
+                            </Grid>
+                        </DockPanel>
                     </TabItem>
 
                     <!-- ===== TEAM ===== -->
@@ -1723,42 +1824,43 @@ Background="DarkSlateGray"  BorderBrush="DarkGoldenrod"/>
 
                     <!-- ===== CAMERAS ===== -->
                     <TabItem Header="Cameras" Style="{StaticResource PrettyTabItem}">
-                        <Grid Margin="0">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <!-- Previews oben -->
-                                <RowDefinition Height="Auto"/>
-                                <!-- Button unten -->
-                            </Grid.RowDefinitions>
-
-                            <!-- Kamera-Previews / Liste -->
-                            <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
-                                <ItemsControl x:Name="CamItems">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <WrapPanel ItemWidth="220" ItemHeight="180"/>
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                </ItemsControl>
-                            </ScrollViewer>
-
+                        <DockPanel LastChildFill="True">
                             <!-- Add Camera unten rechts -->
-                            <StackPanel Grid.Row="1"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Margin="0,10,0,0">
-
-
-                                <!--  Variante B (optional): Icon + Text – falls du den Plus-Glyph behalten willst -->
-                                <Button x:Name="BtnAddCam"
-                    Style="{StaticResource PrimaryButton}">
+                            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                                <Button x:Name="BtnAddCam" Style="{StaticResource PrimaryButton}">
                                     <StackPanel Orientation="Horizontal" Margin="6,1">
                                         <TextBlock Text="🎥 Add Camera"/>
                                     </StackPanel>
                                 </Button>
-
                             </StackPanel>
-                        </Grid>
+
+                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <Grid>
+                                    <ItemsControl x:Name="CamItems">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel ItemWidth="220" ItemHeight="180"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                    </ItemsControl>
+                                    
+                                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False" Margin="0,50">
+                                        <StackPanel.Style>
+                                            <Style TargetType="StackPanel">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HasItems, ElementName=CamItems}" Value="False">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Style>
+                                        <TextBlock Text="No cameras found" Foreground="{StaticResource TextSubtle}" HorizontalAlignment="Center" FontStyle="Italic"/>
+                                        <TextBlock Text="Pair a camera to see its preview here" Foreground="{StaticResource TextSubtle}" FontSize="10" HorizontalAlignment="Center" Opacity="0.6"/>
+                                    </StackPanel>
+                                </Grid>
+                            </ScrollViewer>
+                        </DockPanel>
                     </TabItem>
                 </TabControl>
 

--- a/RustPlusDesktop/MainWindow.xaml
+++ b/RustPlusDesktop/MainWindow.xaml
@@ -821,20 +821,28 @@
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <DockPanel Margin="0,0,0,5">
+                            <Grid Margin="0,0,0,5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
                                 <TextBlock Text="{Binding Selected.Name, FallbackValue='Select a Server'}" 
                                            Foreground="White" FontWeight="Bold" FontSize="18"
-                                           VerticalAlignment="Center"/>
-                                <Button Content="ⓘ Info" 
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"
+                                           Margin="0,0,10,0"/>
+                                <Button Grid.Column="1"
+                                        Content="ⓘ Info" 
                                         Click="BtnShowServerInfo_Click" 
                                         HorizontalAlignment="Right" 
                                         VerticalAlignment="Center"
                                         Style="{StaticResource GhostButton}" 
                                         FontSize="11" 
-                                        Padding="6,2"
+                                        Padding="10,4"
+                                        Margin="5,0,0,0"
                                         Foreground="{StaticResource TextSubtle}"
                                         ToolTip="Show Server Description"/>
-                            </DockPanel>
+                            </Grid>
 
                             <Separator Background="{StaticResource CardBorder}" Margin="0,4,0,8"/>
 

--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -63,9 +63,7 @@ public partial class MainWindow : Window
     private WebView2? _webView;
     private IPairingListener _pairing;
     private readonly Dictionary<uint, DateTime> _entityPairSeen = new();
-    private bool _pairingStarting;
     private string? _lastPairSig;
-    private bool _listenerWired; // damit Events nur einmal verdrahtet werden
     private bool _listenerStarting; // Schutz gegen Doppelklicks
     private readonly System.Windows.Threading.DispatcherTimer _statusTimer =
     new() { Interval = TimeSpan.FromSeconds(30) };
@@ -2898,7 +2896,9 @@ public partial class MainWindow : Window
         {
             var keyHost = (e.Host ?? "").Trim();
             var keyPort = e.Port;
-            var keySteam = string.IsNullOrEmpty(_vm.SteamId64) ? e.SteamId64 : _vm.SteamId64;
+            // PREFER the SteamID from the pairing payload if it exists. 
+            // Only fallback to _vm.SteamId64 if the payload is missing it.
+            var keySteam = !string.IsNullOrEmpty(e.SteamId64) ? e.SteamId64 : _vm.SteamId64;
 
             var prof = _vm.Servers.FirstOrDefault(s =>
                 s.Host.Equals(keyHost, StringComparison.OrdinalIgnoreCase) &&
@@ -3086,25 +3086,39 @@ public partial class MainWindow : Window
             _vm.BusyText = "Starting Pairing-Listener …";
 
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            EventHandler onListen = (_, __) => tcs.TrySetResult(true);
-            EventHandler<string> onFail = (_, __) => tcs.TrySetResult(false);
+            EventHandler onListen = null!; 
+            onListen = (_, __) => { _pairing.Listening -= onListen; tcs.TrySetResult(true); };
+            EventHandler<string> onFail = null!;
+            onFail = (_, msg) => { _pairing.Failed -= onFail; AppendLog("[pairing] Listener failed: " + msg); tcs.TrySetResult(false); };
 
             _pairing.Listening += onListen;
             _pairing.Failed += onFail;
 
-            await _pairing.StartAsync();
+            try
+            {
+                await _pairing.StartAsync();
+            }
+            catch (Exception exStart)
+            {
+                _pairing.Listening -= onListen;
+                _pairing.Failed -= onFail;
+                AppendLog("[pairing] StartAsync exception: " + exStart.Message);
+                tcs.TrySetResult(false);
+            }
 
             // Kleines Safety-Timeout, damit das Overlay nie hängen bleibt
-            var completed = await Task.WhenAny(tcs.Task, Task.Delay(8000));
-            bool ok = (completed == tcs.Task) && tcs.Task.Result;
-
-            // Aufräumen
-            _pairing.Listening -= onListen;
-            _pairing.Failed -= onFail;
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(10000));
+            bool ok = (completed == tcs.Task) && await tcs.Task;
 
             _vm.IsBusy = false;
             _vm.BusyText = "";
             if (ok) TxtPairingState.Text = "Pairing: listening…";
+            else TxtPairingState.Text = "Pairing: failed";
+        }
+        catch (Exception ex)
+        {
+            AppendLog("[pairing] UI Handler Error: " + ex.Message);
+            _vm.IsBusy = false;
         }
         finally
         {
@@ -3264,6 +3278,7 @@ public partial class MainWindow : Window
             var loopback = new SteamOpenIdLoopbackService();
             var sid = await loopback.SignInAsync(); // ggf. Port anpassen
             _vm.SteamId64 = sid;
+            TrackingService.SteamId64 = sid; // Persist globally
             TxtSteamId.Text = sid;
             AppendLog($"Steam angemeldet (Loopback): {sid}");
             _vm.Save();
@@ -3485,7 +3500,45 @@ public partial class MainWindow : Window
 
     private async void BtnHardReset_Click(object sender, RoutedEventArgs e)
     {
-        await HardResetAsync(reconnect: false); // oder true, wenn er direkt wieder verbinden soll
+        var ask = MessageBox.Show(
+            "WIRKLICH ALLES ZURÜCKSETZEN (WIPE)?\n\n" +
+            "- Alle Server werden gelöscht\n" +
+            "- Die Steam-Anmeldung wird entfernt\n" +
+            "- Die Pairing-Konfig wird gelöscht\n\n" +
+            "Fortfahren?", "FULL WIPE", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+
+        if (ask != MessageBoxResult.Yes) return;
+
+        await FullWipeResetAsync();
+    }
+
+    private async Task FullWipeResetAsync()
+    {
+        AppendLog("[WIPE] Starting full reset...");
+        
+        // 1. Connection reset
+        await HardResetAsync(reconnect: false);
+
+        // 2. Clear servers
+        _vm.Servers.Clear();
+        _vm.Save();
+        AppendLog("[WIPE] Servers cleared.");
+
+        // 3. Clear SteamID
+        _vm.SteamId64 = "";
+        TrackingService.SteamId64 = "";
+        AppendLog("[WIPE] Steam credentials removed.");
+
+        // 4. Wipe Pairing Config
+        await ResetPairingConfigAsync(stopListenerFirst: true);
+        AppendLog("[WIPE] Pairing configuration deleted.");
+
+        // 5. Update UI
+        HydrateSteamUiFromStorage();
+        AppendLog("[WIPE] Full wipe completed. Starting new pairing flow...");
+        
+        // Trigger the pairing listener (which will trigger fcm-register because we wiped the config)
+        _ = StartPairingListenerUiAsync();
     }
 
     private async void BtnConnect_Click(object sender, RoutedEventArgs e)
@@ -4321,14 +4374,23 @@ public partial class MainWindow : Window
 
     private void HydrateSteamUiFromStorage()
     {
-        // Falls ViewModel keine SteamID hat: aus gespeicherten Servern ableiten
+        // 1. First try global settings
+        if (string.IsNullOrWhiteSpace(_vm.SteamId64))
+        {
+            _vm.SteamId64 = TrackingService.SteamId64;
+        }
+
+        // 2. Fallback: derive from existing servers
         if (string.IsNullOrWhiteSpace(_vm.SteamId64))
         {
             var sid = _vm.Servers
                          .Select(s => s.SteamId64)
                          .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
             if (!string.IsNullOrWhiteSpace(sid))
+            {
                 _vm.SteamId64 = sid;
+                TrackingService.SteamId64 = sid; // Backfill if found
+            }
         }
 
         // Label setzen + Login-Button ggf. deaktivieren

--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -993,6 +993,8 @@ public partial class MainWindow : Window
         // Initial tracking status update and hook global events
         TrackingService.OnOnlinePlayersUpdated -= OnOnlinePlayersUpdated;
         TrackingService.OnOnlinePlayersUpdated += OnOnlinePlayersUpdated;
+        TrackingService.OnServerInfoUpdated -= OnServerInfoUpdated;
+        TrackingService.OnServerInfoUpdated += OnServerInfoUpdated;
         OnOnlinePlayersUpdated();
         
         // Einmal erzeugen (falls du den Stub behalten willst: try/fallback – aber nur EINMAL zuweisen)
@@ -1115,7 +1117,14 @@ public partial class MainWindow : Window
         
         _monumentWatcher.OnDebug += (s, msg) => AppendLog(msg);
 
-
+        // Auto-connect if enabled
+        if (TrackingService.AutoConnectEnabled && _vm.Selected != null)
+        {
+            _ = Task.Run(async () => {
+                await Task.Delay(2000); // Give UI/WebView time to settle
+                await Dispatcher.InvokeAsync(async () => await PerformConnectAsync(true));
+            });
+        }
     }
 
     // CROSSHAIR \\
@@ -2787,6 +2796,15 @@ public partial class MainWindow : Window
     }
     private void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
+        if (TrackingService.CloseToTrayEnabled)
+        {
+            e.Cancel = true;
+            this.Hide();
+            // We still save profiles just in case
+            try { _vm.Save(); } catch { }
+            return;
+        }
+
         try
         {
             AppendLog($"Speichere Profile → {StorageService.GetProfilesPath()}");
@@ -3473,6 +3491,18 @@ public partial class MainWindow : Window
     private async void BtnConnect_Click(object sender, RoutedEventArgs e)
     {
          await PerformConnectAsync(false);
+    }
+
+    private async void BtnDisconnect_Click(object sender, RoutedEventArgs e)
+    {
+        await HardResetAsync(reconnect: false);
+    }
+
+    private void BtnShowServerInfo_Click(object sender, RoutedEventArgs e)
+    {
+        if (_vm.Selected == null) return;
+        var modal = new Views.ServerInfoModal(_vm.Selected.Name, _vm.Selected.Description) { Owner = this };
+        modal.ShowDialog();
     }
 
     private bool _isReconnecting = false;
@@ -9988,6 +10018,16 @@ public partial class MainWindow : Window
         });
     }
 
+    private void OnServerInfoUpdated(string description)
+    {
+        Dispatcher.Invoke(() => {
+            if (_vm.Selected != null && string.IsNullOrWhiteSpace(_vm.Selected.Description))
+            {
+                _vm.Selected.Description = description;
+            }
+        });
+    }
+
     private void RefreshOnlinePlayersList()
     {
         var players = TrackingService.LastOnlinePlayers;
@@ -10181,42 +10221,7 @@ public partial class MainWindow : Window
         Grid.SetRow(searchBox, 1);
         grid.Children.Add(searchBox);
 
-        // Background tracking toggle
-        var bgCheck = new System.Windows.Controls.CheckBox { 
-            Content = "Always track in background (auto-starts with Windows)",
-            Foreground = Brushes.LightGray,
-            Margin = new Thickness(0,0,0,5),
-            IsChecked = TrackingService.IsBackgroundTrackingEnabled
-        };
-        bgCheck.Checked += (s, e) => SetBackgroundTracking(true);
-        bgCheck.Unchecked += (s, e) => SetBackgroundTracking(false);
-
-        var trayCheck = new System.Windows.Controls.CheckBox { 
-            Content = "Minimize to tray when closing window",
-            Foreground = Brushes.LightGray,
-            Margin = new Thickness(0,0,0,5),
-            IsChecked = TrackingService.CloseToTrayEnabled
-        };
-        trayCheck.Checked += (s, e) => TrackingService.CloseToTrayEnabled = true;
-        trayCheck.Unchecked += (s, e) => TrackingService.CloseToTrayEnabled = false;
-
-        var minCheck = new System.Windows.Controls.CheckBox { 
-            Content = "Start application minimized in tray",
-            Foreground = Brushes.LightGray,
-            Margin = new Thickness(0,0,0,10),
-            IsChecked = TrackingService.StartMinimizedEnabled
-        };
-        minCheck.Checked += (s, e) => TrackingService.StartMinimizedEnabled = true;
-        minCheck.Unchecked += (s, e) => TrackingService.StartMinimizedEnabled = false;
-
         var listContainer = new DockPanel();
-        var controlsStack = new StackPanel();
-        controlsStack.Children.Add(bgCheck);
-        controlsStack.Children.Add(trayCheck);
-        controlsStack.Children.Add(minCheck);
-        listContainer.Children.Add(controlsStack);
-        DockPanel.SetDock(controlsStack, Dock.Top);
-        
         var list = new ListBox { Background = Brushes.Transparent, BorderThickness = new Thickness(0), Foreground = Brushes.White };
         listContainer.Children.Add(list);
 
@@ -10289,31 +10294,6 @@ public partial class MainWindow : Window
         win.ShowDialog();
     }
 
-    private void SetBackgroundTracking(bool enable)
-    {
-        TrackingService.IsBackgroundTrackingEnabled = enable;
-        
-        try
-        {
-            var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true);
-            if (key != null)
-            {
-                if (enable)
-                {
-                    var exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName!;
-                    key.SetValue("RustPlusDeskTracker", $"\"{exePath}\" --background");
-                }
-                else
-                {
-                    key.DeleteValue("RustPlusDeskTracker", false);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            AppendLog($"[error] Failed to update startup registry: {ex.Message}");
-        }
-    }
 
     private void ShowTrackingAnalysisWindow(string? bmId = null)
     {
@@ -10773,6 +10753,12 @@ public partial class MainWindow : Window
         };
         win.Show();
         win.Activate();
+    }
+
+    private void BtnSettings_Click(object sender, RoutedEventArgs e)
+    {
+        var modal = new SettingsModal { Owner = this };
+        modal.ShowDialog();
     }
     private async void BtnCheckUpdates_Click(object sender, RoutedEventArgs e)
     {

--- a/RustPlusDesktop/PairingListenerRealProcess.cs
+++ b/RustPlusDesktop/PairingListenerRealProcess.cs
@@ -1,4 +1,4 @@
-﻿using RustPlusDesk.Models;
+using RustPlusDesk.Models;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -47,8 +47,6 @@ namespace RustPlusDesk.Services
         private string? _pendingAlarmMsg;
         private DateTime? _pendingAlarmMsgTs;
 
-        // NEU: markieren, dass als NÄCHSTES die value:'…' zum body kommt
-        private bool _waitingBodyValue;
         private bool _chatBundleOpen;
         private string? _pendingChatMsg;
         private string? _pendingChatTitle;
@@ -105,6 +103,7 @@ namespace RustPlusDesk.Services
             if (!File.Exists(ConfigPath) || new FileInfo(ConfigPath).Length < 50)
             {
                 _log("Starting one time registration (fcm-register) …");
+                _log("IMPORTANT: Log into the SAME Steam account in your browser that you use in the Rust+ app!");
                 await RunCliWithLoggingAsync(
     node,
     $"\"{cli}\" fcm-register --config-file=\"{ConfigPath}\"",
@@ -135,6 +134,11 @@ namespace RustPlusDesk.Services
                 noWindow: true,
                 redirect: true
             );
+
+            if (_listenProc == null)
+            {
+                throw new InvalidOperationException("Failed to start fcm-listen process.");
+            }
 
             _running = true;
             _listenProc.EnableRaisingEvents = true;
@@ -691,7 +695,7 @@ namespace RustPlusDesk.Services
             return s;
         }
 
-        private Task<int> RunCliWithLoggingAsync(
+        private async Task<int> RunCliWithLoggingAsync(
     string fileName, string args, string? workingDir, string tag, CancellationToken token)
         {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -707,8 +711,17 @@ namespace RustPlusDesk.Services
             p.EnableRaisingEvents = true;
             p.Exited += (_, __) => tcs.TrySetResult(p.ExitCode);
 
-            using (token.Register(() => { try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { } }))
-                return tcs.Task;
+            try
+            {
+                using (token.Register(() => { try { if (p is { HasExited: false }) p.Kill(entireProcessTree: true); } catch { } }))
+                {
+                    return await tcs.Task;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return -1;
+            }
         }
 
 

--- a/RustPlusDesktop/RustPlusDesk.csproj
+++ b/RustPlusDesktop/RustPlusDesk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net8.0-windows</TargetFramework>
@@ -43,10 +43,12 @@
 		<!-- portable Node -->
 		<Content Include="runtime\node-win-x64\**\*">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 		</Content>
 		<!-- CLI-Archiv -->
 		<Content Include="runtime\rustplus-cli.zip">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 		</Content>
 	</ItemGroup>
 	
@@ -289,23 +291,7 @@
     </Page>
   </ItemGroup>
 
-	<!-- 2) DEBUG: nichts Großes kopieren (wir lesen direkt aus dem Projektordner) -->
-	<ItemGroup Condition="'$(Configuration)'=='Debug'">
-		<None Include="runtime\rustplus-cli\**\*" />
-		<None Include="runtime\node-win-x64\**\*" />
-	</ItemGroup>
 
-	<!-- 3) RELEASE: nur die schlanken Assets kopieren -->
-	<ItemGroup Condition="'$(Configuration)'=='Release'">
-		<!-- portable Node mitgeben -->
-		<Content Include="runtime\node-win-x64\**\*">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<!-- CLI nur als ZIP mitgeben -->
-		<Content Include="runtime\rustplus-cli.zip">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
 	
 	<PropertyGroup>
 		<CopyRetryCount>60</CopyRetryCount>

--- a/RustPlusDesktop/ServerInfoModal.xaml
+++ b/RustPlusDesktop/ServerInfoModal.xaml
@@ -1,0 +1,56 @@
+<Window x:Class="RustPlusDesk.Views.ServerInfoModal"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Server Information" 
+        Width="450" Height="350"
+        WindowStartupLocation="CenterOwner"
+        AllowsTransparency="True" 
+        WindowStyle="None"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True">
+    
+    <Border Background="{DynamicResource SurfaceAlt}" 
+            BorderBrush="{DynamicResource CardBorder}" 
+            BorderThickness="2" 
+            CornerRadius="12">
+        <DockPanel Margin="20">
+            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,15">
+                <DockPanel>
+                    <TextBlock Text="Server Information" 
+                               Foreground="White" 
+                               FontSize="20" 
+                               FontWeight="Bold" 
+                               VerticalAlignment="Center"/>
+                    <Button Content="✕" 
+                            HorizontalAlignment="Right" 
+                            Width="30" Height="30"
+                            Style="{StaticResource GhostButton}"
+                            Click="BtnClose_Click"
+                            Cursor="Hand"
+                            FontSize="18"
+                            Foreground="{DynamicResource TextSubtle}"/>
+                </DockPanel>
+                <Separator Background="{DynamicResource CardBorder}" Margin="0,10,0,0"/>
+            </StackPanel>
+
+            <Button DockPanel.Dock="Bottom" 
+                    Content="Close" 
+                    Width="100" 
+                    Height="35"
+                    HorizontalAlignment="Right"
+                    Style="{StaticResource PrimaryButton}"
+                    Click="BtnClose_Click"
+                    Margin="0,15,0,0"/>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <TextBlock x:Name="TxtDescription" 
+                           TextWrapping="Wrap" 
+                           Foreground="White" 
+                           FontSize="14" 
+                           LineHeight="20"
+                           Text="No description available."/>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</Window>

--- a/RustPlusDesktop/ServerInfoModal.xaml.cs
+++ b/RustPlusDesktop/ServerInfoModal.xaml.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+
+namespace RustPlusDesk.Views
+{
+    public partial class ServerInfoModal : Window
+    {
+        public ServerInfoModal(string serverName, string description)
+        {
+            InitializeComponent();
+            Title = serverName;
+            TxtDescription.Text = string.IsNullOrWhiteSpace(description) 
+                ? "No detailed description available for this server." 
+                : description;
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        // Allow dragging the window
+        protected override void OnMouseLeftButtonDown(System.Windows.Input.MouseButtonEventArgs e)
+        {
+            base.OnMouseLeftButtonDown(e);
+            if (e.ButtonState == System.Windows.Input.MouseButtonState.Pressed)
+                DragMove();
+        }
+    }
+}

--- a/RustPlusDesktop/ServerProfile.cs
+++ b/RustPlusDesktop/ServerProfile.cs
@@ -1,20 +1,46 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace RustPlusDesk.Models;
 
 
-public class ServerProfile
+public class ServerProfile : INotifyPropertyChanged
 {
-    public string Name { get; set; } = "";
+    private string _name = "";
+    public string Name
+    {
+        get => _name;
+        set { _name = value; OnProp(); }
+    }
+
+    private string _description = "";
+    public string Description
+    {
+        get => _description;
+        set { _description = value; OnProp(); }
+    }
+
     public string Host { get; set; } = "";
     public int Port { get; set; } = 28082;
     public string SteamId64 { get; set; } = "";
     public string PlayerToken { get; set; } = "";
-    public bool IsConnected { get; set; }
+
+    private bool _isConnected;
+    public bool IsConnected
+    {
+        get => _isConnected;
+        set { _isConnected = value; OnProp(); }
+    }
+
     public bool UseFacepunchProxy { get; set; } = false;
 
     public ObservableCollection<SmartDevice> Devices { get; set; } = new();
     public ObservableCollection<string> CameraIds { get; set; } = new();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnProp([CallerMemberName] string? n = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
 }
 

--- a/RustPlusDesktop/SettingsModal.xaml
+++ b/RustPlusDesktop/SettingsModal.xaml
@@ -1,0 +1,97 @@
+<Window x:Class="RustPlusDesk.Views.SettingsModal"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Application Settings" 
+        Width="500" Height="450"
+        WindowStartupLocation="CenterOwner"
+        AllowsTransparency="True" 
+        WindowStyle="None"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True">
+    
+    <Border Background="{DynamicResource SurfaceAlt}" 
+            BorderBrush="{DynamicResource CardBorder}" 
+            BorderThickness="2" 
+            CornerRadius="12">
+        <DockPanel Margin="20">
+            <!-- Header -->
+            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,20">
+                <DockPanel>
+                    <TextBlock Text="Settings" 
+                               Foreground="White" 
+                               FontSize="22" 
+                               FontWeight="Bold" 
+                               VerticalAlignment="Center"/>
+                    <Button Content="✕" 
+                            HorizontalAlignment="Right" 
+                            Width="30" Height="30"
+                            Style="{StaticResource GhostButton}"
+                            Click="BtnClose_Click"
+                            Cursor="Hand"
+                            FontSize="18"
+                            Foreground="{DynamicResource TextSubtle}"/>
+                </DockPanel>
+                <Separator Background="{DynamicResource CardBorder}" Margin="0,10,0,0"/>
+            </StackPanel>
+
+            <!-- Footer -->
+            <Button DockPanel.Dock="Bottom" 
+                    Content="Close" 
+                    Width="100" 
+                    Height="35"
+                    HorizontalAlignment="Right"
+                    Style="{StaticResource PrimaryButton}"
+                    Click="BtnClose_Click"
+                    Margin="0,15,0,0"/>
+
+            <!-- Content -->
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <TextBlock Text="General" Foreground="{DynamicResource Accent}" FontWeight="Bold" Margin="0,0,0,10"/>
+                    
+                    <CheckBox x:Name="ChkAutoStart" 
+                              Content="Launch with Windows (Minimized)" 
+                              Margin="0,0,0,12" 
+                              Style="{StaticResource DotCheckBox}"
+                              Checked="OnSettingChanged" Unchecked="OnSettingChanged"/>
+
+                    <CheckBox x:Name="ChkStartMinimized" 
+                              Content="Start Minimized (Always)" 
+                              Margin="0,0,0,12" 
+                              Style="{StaticResource DotCheckBox}"
+                              Checked="OnSettingChanged" Unchecked="OnSettingChanged"/>
+
+                    <CheckBox x:Name="ChkAutoConnect" 
+                              Content="Auto-Connect to last server on startup" 
+                              Margin="0,0,0,12" 
+                              Style="{StaticResource DotCheckBox}"
+                              Checked="OnSettingChanged" Unchecked="OnSettingChanged"
+                              ToolTip="Automatically reconnects to the last server and loads the map."/>
+
+                    <TextBlock Text="Behavior" Foreground="{DynamicResource Accent}" FontWeight="Bold" Margin="0,10,0,10"/>
+
+                    <CheckBox x:Name="ChkCloseToTray" 
+                              Content="Minimize to Tray instead of closing" 
+                              Margin="0,0,0,12" 
+                              Style="{StaticResource DotCheckBox}"
+                              Checked="OnSettingChanged" Unchecked="OnSettingChanged"/>
+
+                    <CheckBox x:Name="ChkBackgroundTracking" 
+                              Content="Enable Background Player Tracking" 
+                              Margin="0,0,0,12" 
+                              Style="{StaticResource DotCheckBox}"
+                              Checked="OnSettingChanged" Unchecked="OnSettingChanged"
+                              ToolTip="Keeps tracking players via BattleMetrics even when minimized."/>
+
+                    <TextBlock Text="Steam Account" Foreground="{DynamicResource Accent}" FontWeight="Bold" Margin="0,10,0,10"/>
+                    <TextBlock Text="Manage your linked Steam account in the main window." 
+                               Foreground="{DynamicResource TextSubtle}" 
+                               FontSize="12" 
+                               FontStyle="Italic"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</Window>

--- a/RustPlusDesktop/SettingsModal.xaml.cs
+++ b/RustPlusDesktop/SettingsModal.xaml.cs
@@ -1,0 +1,48 @@
+using System.Windows;
+using RustPlusDesk.Services;
+
+namespace RustPlusDesk.Views
+{
+    public partial class SettingsModal : Window
+    {
+        private bool _isInitialized = false;
+
+        public SettingsModal()
+        {
+            InitializeComponent();
+            LoadSettings();
+            _isInitialized = true;
+        }
+
+        private void LoadSettings()
+        {
+            ChkAutoStart.IsChecked = TrackingService.AutoStartEnabled;
+            ChkStartMinimized.IsChecked = TrackingService.StartMinimizedEnabled;
+            ChkAutoConnect.IsChecked = TrackingService.AutoConnectEnabled;
+            ChkCloseToTray.IsChecked = TrackingService.CloseToTrayEnabled;
+            ChkBackgroundTracking.IsChecked = TrackingService.IsBackgroundTrackingEnabled;
+        }
+
+        private void OnSettingChanged(object sender, RoutedEventArgs e)
+        {
+            if (!_isInitialized) return;
+
+            TrackingService.AutoStartEnabled = ChkAutoStart.IsChecked == true;
+            TrackingService.StartMinimizedEnabled = ChkStartMinimized.IsChecked == true;
+            TrackingService.AutoConnectEnabled = ChkAutoConnect.IsChecked == true;
+            TrackingService.CloseToTrayEnabled = ChkCloseToTray.IsChecked == true;
+            TrackingService.IsBackgroundTrackingEnabled = ChkBackgroundTracking.IsChecked == true;
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        protected override void OnMouseLeftButtonDown(System.Windows.Input.MouseButtonEventArgs e)
+        {
+            base.OnMouseLeftButtonDown(e);
+            DragMove();
+        }
+    }
+}

--- a/RustPlusDesktop/Setup.iss
+++ b/RustPlusDesktop/Setup.iss
@@ -1,0 +1,116 @@
+; =============================================
+; RustPlusDesk Installer (Production)
+; Fixes uninstall + supports upgrades
+; =============================================
+
+[Setup]
+; 🔴 NEVER CHANGE THIS GUID AGAIN (identity of your app forever)
+AppId={{7B4E7E6A-7D52-4F7B-AF4E-7A7D8F1C9B21}}
+
+AppName=RustPlusDesk
+AppVersion=3.5.3
+AppPublisher=RustPlusDesk
+AppPublisherURL=https://github.com/Pronwan/rustplus-desktop
+
+DefaultDirName={autopf}\RustPlusDesk
+DefaultGroupName=RustPlusDesk
+
+; Fixes upgrades + broken previous installs
+UsePreviousAppDir=yes
+UsePreviousGroup=yes
+CreateUninstallRegKey=yes
+
+; Installer output
+OutputDir=bin\Installer
+OutputBaseFilename=RustPlusDesk-Setup
+
+; Compression
+Compression=lzma2/max
+SolidCompression=yes
+
+; UI / permissions
+SetupIconFile=rustplus-desktop-icon.ico
+UninstallDisplayIcon={app}\RustPlusDesk.exe
+PrivilegesRequired=admin
+WizardStyle=modern
+
+; Optional but recommended
+ArchitecturesInstallIn64BitMode=x64
+DisableProgramGroupPage=yes
+
+; =============================================
+
+[Tasks]
+Name: "desktopicon"; \
+Description: "{cm:CreateDesktopIcon}"; \
+GroupDescription: "{cm:AdditionalIcons}"; \
+Flags: unchecked
+
+; =============================================
+
+[Files]
+; Main EXE (single-file publish)
+Source: "bin\Installer\publish\RustPlusDesk.exe"; \
+DestDir: "{app}"; Flags: ignoreversion
+
+; Native runtime files
+Source: "bin\Installer\publish\runtime\*"; \
+DestDir: "{app}\runtime"; \
+Flags: ignoreversion recursesubdirs createallsubdirs
+
+; Icons
+Source: "bin\Installer\publish\icons\*"; \
+DestDir: "{app}\icons"; \
+Flags: ignoreversion recursesubdirs createallsubdirs
+
+; Data files
+Source: "bin\Installer\publish\rust_items.json"; \
+DestDir: "{app}"; Flags: ignoreversion
+
+Source: "bin\Installer\publish\cash.wav"; \
+DestDir: "{app}"; Flags: ignoreversion
+
+; =============================================
+
+[Icons]
+Name: "{group}\RustPlusDesk"; Filename: "{app}\RustPlusDesk.exe"
+Name: "{autodesktop}\RustPlusDesk"; Filename: "{app}\RustPlusDesk.exe"; Tasks: desktopicon
+
+; =============================================
+
+[Run]
+Filename: "{app}\RustPlusDesk.exe"; \
+Description: "{cm:LaunchProgram,RustPlusDesk}"; \
+Flags: nowait postinstall skipifsilent
+
+; =============================================
+
+[UninstallDelete]
+; Clean leftover runtime/data folders on uninstall
+Type: filesandordirs; Name: "{app}\runtime"
+Type: filesandordirs; Name: "{app}\icons"
+
+; =============================================
+[Code]
+
+procedure DeleteOldBrokenUninstallers;
+var
+  Key: string;
+begin
+  Key := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\RustPlusDesk';
+
+  RegDeleteKeyIncludingSubkeys(HKLM, Key);
+  RegDeleteKeyIncludingSubkeys(HKCU, Key);
+
+  Key := 'Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RustPlusDesk';
+
+  RegDeleteKeyIncludingSubkeys(HKLM, Key);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssInstall then
+  begin
+    DeleteOldBrokenUninstallers;
+  end;
+end;

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -25,6 +25,8 @@ public class TrackingSettings
     public bool BackgroundTrackingEnabled { get; set; } = false;
     public bool CloseToTrayEnabled { get; set; } = false;
     public bool StartMinimizedEnabled { get; set; } = false;
+    public bool AutoConnectEnabled { get; set; } = false;
+    public bool AutoStartEnabled { get; set; } = false;
 }
 
 public class PlayerSession
@@ -62,6 +64,7 @@ public static class TrackingService
     private static string? _lastServerName;
 
     public static event Action? OnOnlinePlayersUpdated;
+    public static event Action<string>? OnServerInfoUpdated;
     public static string StatusMessage { get; private set; } = "";
     public static List<OnlinePlayerBM> LastOnlinePlayers { get; private set; } = new();
     public static DateTime? LastPullTime { get; private set; }
@@ -162,6 +165,46 @@ public static class TrackingService
     {
         get => _settings.StartMinimizedEnabled;
         set { _settings.StartMinimizedEnabled = value; SaveDB(); }
+    }
+
+    public static bool AutoConnectEnabled
+    {
+        get => _settings.AutoConnectEnabled;
+        set { _settings.AutoConnectEnabled = value; SaveDB(); }
+    }
+
+    public static bool AutoStartEnabled
+    {
+        get => _settings.AutoStartEnabled;
+        set 
+        { 
+            if (_settings.AutoStartEnabled == value) return;
+            _settings.AutoStartEnabled = value; 
+            SetAutoStart(value);
+            SaveDB(); 
+        }
+    }
+
+    private static void SetAutoStart(bool enabled)
+    {
+        try
+        {
+            const string runKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
+            using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(runKey, true);
+            if (key == null) return;
+
+            string appName = "RustPlusDesk";
+            if (enabled)
+            {
+                string exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName!;
+                key.SetValue(appName, $"\"{exePath}\" --background");
+            }
+            else
+            {
+                key.DeleteValue(appName, false);
+            }
+        }
+        catch { }
     }
 
     public static (string host, int port, string name) LastServer => (_settings.LastHost, _settings.LastPort, _settings.LastServerName);
@@ -457,6 +500,11 @@ public static class TrackingService
                         // CRITICAL: Wir nehmen den Server nur, wenn die IP EXAKT stimmt
                         if (foundIp == _lastServerHost)
                         {
+                            if (attr.TryGetProperty("details", out var details) && details.TryGetProperty("rust_description", out var desc))
+                            {
+                                OnServerInfoUpdated?.Invoke(desc.GetString() ?? "");
+                            }
+
                             // Wenn wir mehrere Server auf einer IP haben (Shared Hosting), 
                             // nehmen wir den, dessen Name am besten passt.
                             if (string.IsNullOrEmpty(_lastServerName) || foundName.Contains(_lastServerName, StringComparison.OrdinalIgnoreCase))
@@ -517,6 +565,15 @@ public static class TrackingService
 
             var pRes = await responsePlayers.Content.ReadAsStringAsync();
             using var pDoc = JsonDocument.Parse(pRes);
+
+            if (pDoc.RootElement.TryGetProperty("data", out var serverData))
+            {
+                var attr = serverData.GetProperty("attributes");
+                if (attr.TryGetProperty("details", out var details) && details.TryGetProperty("rust_description", out var desc))
+                {
+                    OnServerInfoUpdated?.Invoke(desc.GetString() ?? "");
+                }
+            }
             
             var onlineList = new List<OnlinePlayerBM>();
             var newOnlineIds = new HashSet<string>();

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -40,6 +40,7 @@ public class OnlinePlayerBM
 {
     public string Name { get; set; } = string.Empty;
     public string BMId { get; set; } = string.Empty;
+    public DateTime SessionStartTimeUtc { get; set; }
     public TimeSpan Duration { get; set; }
     public bool IsTracked { get; set; }
     public string PlayTimeStr => $"{(int)Duration.TotalHours:D2}:{Duration.Minutes:D2}";
@@ -106,6 +107,20 @@ public static class TrackingService
 
             var jsonS = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(_settingsPath, jsonS);
+        }
+        catch { }
+    }
+
+    private static void Log(string message)
+    {
+        try
+        {
+            var logPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "RustPlusDesk", "tracking_log.txt");
+            var dir = Path.GetDirectoryName(logPath);
+            if (dir != null && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+            File.AppendAllText(logPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}{Environment.NewLine}");
         }
         catch { }
     }
@@ -366,7 +381,13 @@ public static class TrackingService
                 var statusText = isOnline ? "Online" : "Offline";
                 sb.AppendLine($"<div style='margin-bottom:20px;'><span class='badge {statusClass}'>{statusText}</span></div>");
 
+                var lastS = p.Sessions.LastOrDefault();
+                string lastConnectedStr = lastS != null ? lastS.ConnectTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm") : "Never";
+                string lastSeenStr = lastS != null ? (lastS.DisconnectTime?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "Active Now") : "Never";
+
                 sb.AppendLine("<div class='stat-grid'>");
+                sb.AppendLine("<div class='stat-item'><div class='stat-label'>Last Connected</div><div class='stat-value'>" + lastConnectedStr + "</div></div>");
+                sb.AppendLine("<div class='stat-item'><div class='stat-label'>Last Seen</div><div class='stat-value'>" + lastSeenStr + "</div></div>");
                 sb.AppendLine("<div class='stat-item'><div class='stat-label'>Total Tracked Time</div><div class='stat-value'>" + $"{(int)totalTime.TotalHours}h {totalTime.Minutes}m" + "</div></div>");
                 sb.AppendLine("<div class='stat-item'><div class='stat-label'>Last 7 Days</div><div class='stat-value'>" + $"{(int)past7Days.TotalHours}h {past7Days.Minutes}m" + "</div></div>");
                 sb.AppendLine("<div class='stat-item'><div class='stat-label'>Session Count</div><div class='stat-value'>" + p.Sessions.Count + "</div></div>");
@@ -581,7 +602,7 @@ public static class TrackingService
             }
             
             var onlineList = new List<OnlinePlayerBM>();
-            var newOnlineIds = new HashSet<string>();
+            var newOnlineIds = new Dictionary<string, DateTime>();
 
             if (pDoc.RootElement.TryGetProperty("included", out var included))
             {
@@ -604,10 +625,12 @@ public static class TrackingService
                         if (string.IsNullOrEmpty(bmId)) continue;
 
                         int seconds = 0;
+                        DateTime actualStart = DateTime.UtcNow;
                         if (attr.TryGetProperty("start", out var sProp) && sProp.ValueKind == JsonValueKind.String)
                         {
                             if (DateTimeOffset.TryParse(sProp.GetString(), out var start))
                             {
+                                actualStart = start.UtcDateTime;
                                 seconds = (int)(DateTimeOffset.UtcNow - start).TotalSeconds;
                             }
                         }
@@ -616,10 +639,11 @@ public static class TrackingService
                         {
                             BMId = bmId,
                             Name = name,
+                            SessionStartTimeUtc = actualStart,
                             Duration = TimeSpan.FromSeconds(Math.Max(0, seconds)),
                             IsTracked = _trackedPlayers.ContainsKey(bmId)
                         });
-                        newOnlineIds.Add(bmId);
+                        newOnlineIds[bmId] = actualStart;
                     }
                 }
             }
@@ -638,7 +662,7 @@ public static class TrackingService
             OnOnlinePlayersUpdated?.Invoke();
 
             // 3. Update Tracking stats
-            UpdateTrackingStats(newOnlineIds);
+            await UpdateTrackingStatsAsync(newOnlineIds);
         }
         catch (Exception ex)
         {
@@ -647,31 +671,65 @@ public static class TrackingService
         }
     }
 
-    private static void UpdateTrackingStats(HashSet<string> currentlyOnlineIds)
+    private static async Task UpdateTrackingStatsAsync(Dictionary<string, DateTime> currentlyOnlineWithStart)
     {
         bool changed = false;
         var now = DateTime.UtcNow;
 
         foreach (var tp in _trackedPlayers.Values)
         {
-            bool isOnline = currentlyOnlineIds.Contains(tp.BMId);
+            bool isOnline = currentlyOnlineWithStart.TryGetValue(tp.BMId, out var actualConnectTime);
             var lastSession = tp.Sessions.LastOrDefault();
 
             if (isOnline)
             {
                 if (lastSession == null || lastSession.DisconnectTime.HasValue)
                 {
-                    // Newly connected
-                    tp.Sessions.Add(new PlayerSession { ConnectTime = now, DisconnectTime = null });
+                    // Newly connected or we just started tracking/opened the app
+                    tp.Sessions.Add(new PlayerSession { ConnectTime = actualConnectTime, DisconnectTime = null });
+                    Log($"[SESSION] {tp.Name} ({tp.BMId}) connected at {actualConnectTime:yyyy-MM-dd HH:mm:ss} UTC (detected at {now:HH:mm})");
                     changed = true;
+                }
+                else
+                {
+                    // If we have an open session, but the connect time is different (e.g. app was closed and they rejoined)
+                    // BattleMetrics session ID would change, but here we track by server session.
+                    // If the actualConnectTime is NEWER than our last recorded ConnectTime, they must have reconnected 
+                    // while we were closed.
+                    if (actualConnectTime > lastSession.ConnectTime.AddMinutes(5))
+                    {
+                        // They reconnected. Close old session at their last seen or roughly before this connect?
+                        // For simplicity, we close the old one at actualConnectTime - 1 second and start new one.
+                        lastSession.DisconnectTime = actualConnectTime.AddSeconds(-1);
+                        tp.Sessions.Add(new PlayerSession { ConnectTime = actualConnectTime, DisconnectTime = null });
+                        Log($"[SESSION] {tp.Name} reconnected (missed disconnect). New session start: {actualConnectTime:yyyy-MM-dd HH:mm:ss} UTC");
+                        changed = true;
+                    }
+                    else if (Math.Abs((lastSession.ConnectTime - actualConnectTime).TotalMinutes) > 1)
+                    {
+                        // Small correction of start time
+                        lastSession.ConnectTime = actualConnectTime;
+                        changed = true;
+                    }
                 }
             }
             else
             {
                 if (lastSession != null && !lastSession.DisconnectTime.HasValue)
                 {
-                    // Newly disconnected
-                    lastSession.DisconnectTime = now;
+                    // Newly disconnected. Fetch actual last seen/stop time.
+                    var actualDisconnectTime = await FetchLastSeenTimeAsync(tp.BMId);
+                    if (actualDisconnectTime == DateTime.MinValue)
+                    {
+                        actualDisconnectTime = now;
+                        Log($"[SESSION] {tp.Name} disconnected. API stop time fetch failed, using fallback: {now:yyyy-MM-dd HH:mm:ss} UTC");
+                    }
+                    else
+                    {
+                        Log($"[SESSION] {tp.Name} disconnected at {actualDisconnectTime:yyyy-MM-dd HH:mm:ss} UTC");
+                    }
+                    
+                    lastSession.DisconnectTime = actualDisconnectTime;
                     changed = true;
                 }
             }
@@ -681,5 +739,32 @@ public static class TrackingService
         {
             SaveDB();
         }
+    }
+
+    private static async Task<DateTime> FetchLastSeenTimeAsync(string bmId)
+    {
+        if (string.IsNullOrEmpty(_foundServerId)) return DateTime.MinValue;
+
+        try
+        {
+            // Fetch server-specific player information (free endpoint)
+            var url = $"https://api.battlemetrics.com/players/{bmId}/servers/{_foundServerId}";
+            var json = await _http.GetStringAsync(url);
+            using var doc = JsonDocument.Parse(json);
+            
+            if (doc.RootElement.TryGetProperty("data", out var data) && 
+                data.TryGetProperty("attributes", out var attr))
+            {
+                if (attr.TryGetProperty("lastSeen", out var stopProp) && stopProp.ValueKind == JsonValueKind.String)
+                {
+                    if (DateTimeOffset.TryParse(stopProp.GetString(), out var stop))
+                    {
+                        return stop.UtcDateTime;
+                    }
+                }
+            }
+        }
+        catch { }
+        return DateTime.MinValue;
     }
 }

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -42,9 +42,7 @@ public class OnlinePlayerBM
     public string BMId { get; set; } = string.Empty;
     public TimeSpan Duration { get; set; }
     public bool IsTracked { get; set; }
-    public string PlayTimeStr => Duration.TotalHours >= 1 
-        ? $"{(int)Duration.TotalHours}h {Duration.Minutes}m" 
-        : $"{Duration.Minutes}m";
+    public string PlayTimeStr => $"{(int)Duration.TotalHours:D2}:{Duration.Minutes:D2}";
 }
 
 public static class TrackingService
@@ -561,7 +559,7 @@ public static class TrackingService
 
             // 2. Get Players using the ID we found
             StatusMessage = "Fetching players...";
-            var reqUrl = $"https://api.battlemetrics.com/servers/{_foundServerId}?include=player";
+            var reqUrl = $"https://api.battlemetrics.com/servers/{_foundServerId}?include=session";
             using var responsePlayers = await _http.GetAsync(reqUrl);
             if (!responsePlayers.IsSuccessStatusCode)
             {
@@ -589,38 +587,36 @@ public static class TrackingService
             {
                 foreach (var inc in included.EnumerateArray())
                 {
-                    if (inc.GetProperty("type").GetString() == "player")
+                    string type = inc.TryGetProperty("type", out var tProp) ? tProp.GetString() ?? "" : "";
+                    if (type == "session")
                     {
-                        var bmId = inc.GetProperty("id").GetString() ?? "";
-                        var name = inc.GetProperty("attributes").GetProperty("name").GetString() ?? "Unknown";
-                        int seconds = 0;
-                        if (inc.TryGetProperty("meta", out var meta))
+                        var attr = inc.GetProperty("attributes");
+                        var name = attr.TryGetProperty("name", out var nProp) ? nProp.GetString() ?? "Unknown" : "Unknown";
+                        var bmId = "";
+                        
+                        if (inc.TryGetProperty("relationships", out var rel) && 
+                            rel.TryGetProperty("player", out var pRel) &&
+                            pRel.TryGetProperty("data", out var pData))
                         {
-                            // Playtime is often in a metadata array as 'time' key
-                            if (meta.TryGetProperty("metadata", out var metaArr) && metaArr.ValueKind == JsonValueKind.Array)
-                            {
-                                foreach (var mObj in metaArr.EnumerateArray())
-                                {
-                                    if (mObj.TryGetProperty("key", out var k) && k.GetString() == "time" && 
-                                        mObj.TryGetProperty("value", out var v))
-                                    {
-                                        seconds = v.ValueKind == JsonValueKind.Number ? v.GetInt32() : 0;
-                                        break;
-                                    }
-                                }
-                            }
-                            // Fallback to direct 'time' property if present
-                            else if (meta.TryGetProperty("time", out var timeProp))
-                            {
-                                seconds = timeProp.GetInt32();
-                            }
+                            bmId = pData.GetProperty("id").GetString() ?? "";
                         }
                         
+                        if (string.IsNullOrEmpty(bmId)) continue;
+
+                        int seconds = 0;
+                        if (attr.TryGetProperty("start", out var sProp) && sProp.ValueKind == JsonValueKind.String)
+                        {
+                            if (DateTimeOffset.TryParse(sProp.GetString(), out var start))
+                            {
+                                seconds = (int)(DateTimeOffset.UtcNow - start).TotalSeconds;
+                            }
+                        }
+
                         onlineList.Add(new OnlinePlayerBM
                         {
                             BMId = bmId,
                             Name = name,
-                            Duration = TimeSpan.FromSeconds(seconds),
+                            Duration = TimeSpan.FromSeconds(Math.Max(0, seconds)),
                             IsTracked = _trackedPlayers.ContainsKey(bmId)
                         });
                         newOnlineIds.Add(bmId);

--- a/RustPlusDesktop/TrackingService.cs
+++ b/RustPlusDesktop/TrackingService.cs
@@ -27,6 +27,7 @@ public class TrackingSettings
     public bool StartMinimizedEnabled { get; set; } = false;
     public bool AutoConnectEnabled { get; set; } = false;
     public bool AutoStartEnabled { get; set; } = false;
+    public string SteamId64 { get; set; } = string.Empty;
 }
 
 public class PlayerSession
@@ -183,6 +184,12 @@ public static class TrackingService
             SetAutoStart(value);
             SaveDB(); 
         }
+    }
+
+    public static string SteamId64
+    {
+        get => _settings.SteamId64;
+        set { _settings.SteamId64 = value; SaveDB(); }
     }
 
     private static void SetAutoStart(bool enabled)

--- a/RustPlusDesktop/ViewModel.cs
+++ b/RustPlusDesktop/ViewModel.cs
@@ -117,6 +117,7 @@ public class MainViewModel : INotifyPropertyChanged
         {
             p.Devices ??= new ObservableCollection<SmartDevice>(); // niemals null
             p.CameraIds ??= new ObservableCollection<string>();      // NEU: ebenso niemals null
+            p.IsConnected = false; // Reset connection state on load
             Servers.Add(p);
         }
 


### PR DESCRIPTION


## 1. Improved Player Session Accuracy
**Commit**: `34d4d66`

Enhanced the player tracking accuracy by leveraging direct BattleMetrics API timestamps instead of local timers.
- **Session Start Time**: Added `SessionStartTimeUtc` property to track exact connection times from the API.
- **Disconnection Handling**: Updated to use the player-specific endpoint to fetch precise "last seen" times when disconnections occur.
- **UI Updates**: Added "Last Connected" and "Last Seen" displays to the player info panel.
- **Reliability**: Implemented structured logging for session events and replaced `UpdateTrackingStats` with an async version.
- 
<img width="883" height="1145" alt="image" src="https://github.com/user-attachments/assets/cbb36751-721b-40aa-8861-c6b417188992" />


## 2. Fixed BattleMetrics API Integration
**Commit**: `87f268d`

Resolved issues related to upstream changes in the BattleMetrics API.
- **Endpoint Migration**: Switched from the deprecated `/player` endpoint to the new `/session` endpoint for fetching online players.
- **JSON Parsing**: Updated the parsing logic to accommodate the new API response structure.
- **Data Formatting**: Changed playtime formatting to a standardized `HH:mm` format and recalculated session durations using accurate session start times instead of generic metadata fields.

## 3. Steam ID Persistence & UI/UX Improvements
**Commit**: `cb14c84`

Streamlined the core user experience and improved application stability.
- **State Management**: Persisted the user's Steam ID globally in the `TrackingService` to maintain it across sessions.
- **UI Enhancements**: Improved the layout and text trimming of the server info button. Fixed a tray icon context menu focus bug using a `SetForegroundWindow` workaround.
- **Pairing Listener**: Enhanced reliability with better error handling and timeouts.
- **App Management**: Added full wipe/reset functionality with a confirmation dialog.
- **Deployment**: Cleaned up redundant code, updated the project SDK, and simplified runtime asset handling for clean single-file deployment.

## 4. Server Info Modal, Settings Modal & Auto-Connect
**Commit**: `f0ed421`

Introduced new dedicated interfaces for settings and server details, alongside new startup behaviors.
- **Server Info Modal**: Created `ServerInfoModal` to fetch and display detailed server descriptions from BattleMetrics.
- **Settings Modal**: Added a centralized `SettingsModal` for application configuration.
- **Startup Behaviors**: Implemented auto-connect on startup and improved minimize-to-tray functionality.
- **Data Binding**: Enhanced `ServerProfile` with `INotifyPropertyChanged` and a description field for real-time UI updates.
- **Refactoring**: Updated the tracking service to support auto-start via registry and integrated a dedicated connection card with empty state messages in the main UI.

_____________________________

improved devices list styling 
<img width="1028" height="416" alt="image" src="https://github.com/user-attachments/assets/76c0d16c-ae8a-45ee-afaf-7e056906fefa" />
Hover effect
<img width="1041" height="366" alt="image" src="https://github.com/user-attachments/assets/085fa4c0-9d8a-4b9f-9f09-043f82f6766e" />






<img width="647" height="525" alt="image" src="https://github.com/user-attachments/assets/9437fc35-c9ba-4d9c-8366-832fe4717093" />
<img width="759" height="390" alt="image" src="https://github.com/user-attachments/assets/5af7d2c8-5132-4a8b-82b6-6e6fb19c17f9" />
<img width="440" height="347" alt="image" src="https://github.com/user-attachments/assets/54f9c83b-8b4d-4561-ac3f-c9a2642476bb" />

____________________________________________
added empty state for devices and cameras lists when no devices are added without touching the functionality
<img width="630" height="296" alt="image" src="https://github.com/user-attachments/assets/2bbc7aa8-4e9c-41e7-937d-5b749ab5fc4a" />

<img width="619" height="287" alt="image" src="https://github.com/user-attachments/assets/060dd481-b992-4ff3-a7a6-5691315c3e53" />

__________________________________________________
controls now show no matter the window height unless it hides the tabs themselves 
<img width="397" height="77" alt="image" src="https://github.com/user-attachments/assets/b14ab809-1344-4a22-9e00-04e524bbdc1d" />
___________________________________________________
removed options from tracked players list as they been moved to settings Modal 
<img width="481" height="639" alt="image" src="https://github.com/user-attachments/assets/caa14fcc-4b57-49f0-b0ae-7274eb52b7c0" />

change the placeholder of view tracked player list  from view tracking analysis to view tracked players list 
- fix current session playtime showing 0mins
<img width="322" height="296" alt="image" src="https://github.com/user-attachments/assets/a390b82c-4847-4e5e-83a6-1464dfee2692" />

