### PR TITLE
Fix: Prevent duplicate Compile items during publish

### DIFF
--- a/RustPlusDesktop/RustPlusDesk.csproj
+++ b/RustPlusDesktop/RustPlusDesk.csproj
@@ -706,6 +706,7 @@
 	<Target Name="ObfuscateSecretsTarget" BeforeTargets="BeforeBuild">
 		<Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\obfuscate_secrets.ps1&quot; &quot;$(MSBuildProjectDirectory)&quot;" />
 		<ItemGroup>
+			<Compile Remove="Services\Data\ObfuscatedSecrets.cs" />
 			<Compile Include="Services\Data\ObfuscatedSecrets.cs" />
 		</ItemGroup>
 	</Target>


### PR DESCRIPTION
This PR resolves the dotnet publish failure caused by duplicate Compile items of ObfuscatedSecrets.cs by executing Compile Remove before Compile Include.