### PR TITLE
Fix: Reset tooltip and name on avatar load

### DIFF
--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -4275,6 +4275,9 @@ private sealed record MarkerRef(System.Windows.Shapes.Ellipse Dot, double U_DIP,
             return;
         }
 
+        ImgSteam.ToolTip = "Logged In";
+        TxtSteamName.Text = "Logged In";
+
         var cachePath = GetOwnAvatarCachePath(steamId64);
 
         // Try load from local cache first on start


### PR DESCRIPTION
This PR prevents displaying the previous profile's name if the Steam XML fetch fails or is pending by resetting the tooltip and text to 'Logged In' initially.