### PR TITLE
fix(updater): remove the timeout that made large updates impossible t…

### DIFF
--- a/RustPlusDesktop/MainWindow.xaml.cs
+++ b/RustPlusDesktop/MainWindow.xaml.cs
@@ -7491,7 +7491,18 @@ private sealed record MarkerRef(System.Windows.Shapes.Ellipse Dot, double U_DIP,
 
             if (path == null)
             {
-                ShowInfoSnackbar(Properties.Resources.GetString("UpdateTitle"), Properties.Resources.GetString("DownloadFailed"), WpfUi.ControlAppearance.Danger);
+                // The reason, when there is one. A bare "Download failed" tells neither the
+                // user nor us whether it was the network, the disk or something else.
+                string reason = _updateService.LastDownloadError;
+                if (!string.IsNullOrWhiteSpace(reason))
+                    AppendLog("❌ Update download failed: " + reason);
+
+                ShowInfoSnackbar(
+                    Properties.Resources.GetString("UpdateTitle"),
+                    string.IsNullOrWhiteSpace(reason)
+                        ? Properties.Resources.GetString("DownloadFailed")
+                        : string.Format(Properties.Resources.GetString("FormatDownloadFailed"), reason),
+                    WpfUi.ControlAppearance.Danger);
                 return;
             }
 

--- a/RustPlusDesktop/RustPlusDesk.csproj
+++ b/RustPlusDesktop/RustPlusDesk.csproj
@@ -25,7 +25,7 @@
 
 	<PropertyGroup>
 		<!-- Single source of truth for app, assembly, package, UI, and installer versioning. -->
-		<Version>8.0.0</Version>
+		<Version>8.0.1</Version>
 		<Title>Rust+ Desk</Title>
 		<Authors>Pronwan</Authors>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>

--- a/RustPlusDesktop/Services/UpdateService.cs
+++ b/RustPlusDesktop/Services/UpdateService.cs
@@ -276,6 +276,10 @@ namespace RustPlusDesk.Services
         private CancellationTokenSource? _downloadCts = null;
         public string CurrentDownloadFile { get; private set; } = string.Empty;
 
+        /// <summary>Why the last download failed, or empty. "Download failed" alone is useless
+        /// to whoever has to work out whether it was the network, the disk or a timeout.</summary>
+        public string LastDownloadError { get; private set; } = string.Empty;
+
         public bool IsDownloadPaused => _isDownloadPaused;
 
         public void PauseDownload()
@@ -322,7 +326,15 @@ namespace RustPlusDesk.Services
 
             try
             {
-                using var http = new HttpClient();
+                using var http = new HttpClient
+                {
+                    // No wall-clock limit. The default is 100 seconds and it covers the whole
+                    // transfer, not just the connect — so a 500 MB installer split into four
+                    // chunks needed roughly 40 Mbit/s sustained just to avoid being cancelled
+                    // mid-download. Anyone slower could never finish, however long they waited.
+                    // Cancelling and pausing run through _downloadCts and are unaffected.
+                    Timeout = System.Threading.Timeout.InfiniteTimeSpan
+                };
                 http.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("RustPlusDesk", VersionForCompare.ToString()));
 
                 long totalBytes;
@@ -418,13 +430,18 @@ namespace RustPlusDesk.Services
                 PendingInstallerPath = target;
                 return target;
             }
-            catch (OperationCanceledException)
+            // Only when *we* cancelled. HttpClient reports its own timeout as a
+            // TaskCanceledException as well, and without this filter it was swallowed here as
+            // though the user had pressed cancel — which is why a failed download said nothing
+            // at all, in the log or anywhere else.
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
                 return _isDownloadPaused ? "PAUSED" : null;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Multi-part download failed: {ex.Message}");
+                LastDownloadError = ex.Message;
+                Debug.WriteLine($"Multi-part download failed: {ex}");
                 return null;
             }
         }
@@ -439,7 +456,8 @@ namespace RustPlusDesk.Services
                 return;
             }
 
-            using var http = new HttpClient();
+            // Same reasoning as above: this is the client that actually moves the bytes.
+            using var http = new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
             http.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("RustPlusDesk", VersionForCompare.ToString()));
 
             var request = new HttpRequestMessage(HttpMethod.Get, url);

--- a/RustPlusDesktop/Views/Windows/PatchNotesWindow.xaml
+++ b/RustPlusDesktop/Views/Windows/PatchNotesWindow.xaml
@@ -33,6 +33,24 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <StackPanel x:Name="PatchNotesContent" Margin="0,0,0,12">
                     <!-- ============================================== -->
+                    <!-- NEW v8.0.1 HOTFIX PATCH NOTES -->
+                    <!-- ============================================== -->
+                    <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="10" Padding="10" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="v8.0.1 | Update Download Hotfix" FontWeight="SemiBold" FontSize="16" Margin="0,0,0,8" Foreground="{DynamicResource Accent}"/>
+
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Large updates could never finish downloading:</Run>
+                                The update download had no time limit of its own and fell back on the 100-second default, which covers the entire transfer rather than just the connection. With 8.0.0 at roughly 500&#xA0;MB split into four parts, that required about 40&#xA0;Mbit/s sustained just to avoid being cancelled mid-download &#x2014; anyone slower could never finish, however long they waited. The limit is gone; cancelling and pausing work exactly as before.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; A failed download now says why:</Run>
+                                The timeout was reported as if you had pressed cancel, so nothing appeared in the log and the message read only &quot;Download failed&quot;. Real failures are now separated from cancellations and the reason is shown and logged.
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- ============================================== -->
                     <!-- NEW v8.0.0 PATCH NOTES -->
                     <!-- ============================================== -->
                     <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="10" Padding="10" Margin="0,0,0,10">


### PR DESCRIPTION
…o download

The download used HttpClient with no Timeout set, so it took the 100-second default. That default covers the whole transfer, not just establishing the connection. With 8.0.0 at roughly 500 MB split into four parallel chunks, each chunk had to move about 126 MB inside those 100 seconds — around 40 Mbit/s sustained. Anyone slower was cancelled mid-download every single time, no matter how long they waited.

Worse, it was invisible. HttpClient reports its own timeout as a TaskCanceledException, which the first catch swallowed as though the user had pressed cancel, so the logging branch below it never ran. Users saw 'Download failed' and there was nothing in the log, here or anywhere else.

Both clients now run without a wall-clock limit — cancelling and pausing go through _downloadCts and are unaffected — and the cancellation catch is filtered on our own token, so a genuine failure reaches the log and the message.

Version 8.0.1.