### PR TITLE
Beta

### DIFF
--- a/RustPlusDesktop/RustPlusDesk.csproj
+++ b/RustPlusDesktop/RustPlusDesk.csproj
@@ -25,7 +25,7 @@
 
 	<PropertyGroup>
 		<!-- Single source of truth for app, assembly, package, UI, and installer versioning. -->
-		<Version>8.0.1</Version>
+		<Version>8.0.2</Version>
 		<Title>Rust+ Desk</Title>
 		<Authors>Pronwan</Authors>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>

--- a/RustPlusDesktop/Services/Auth/TeamSyncWebSocketService.cs
+++ b/RustPlusDesktop/Services/Auth/TeamSyncWebSocketService.cs
@@ -188,9 +188,16 @@ namespace RustPlusDesk.Services.Auth
             catch (Exception ex)
             {
                 AppendLog($"[TeamSyncWS/Error] Failed to subscribe to broadcast: {ex.Message}");
+
+                // Drop it properly rather than only letting go of our reference. A channel left
+                // behind in the client's registry is handed back to the next attempt, which
+                // then fails the same way — which is how one failure turned into a dead clan
+                // chat for the rest of the session.
+                if (_broadcastChannel != null) DropChannel(_broadcastChannel);
                 _broadcastChannel = null;
                 _broadcast = null;
                 _broadcastSubscribed = false;
+                _subscribedBroadcastChannel = null;
             }
             finally
             {
@@ -206,7 +213,7 @@ namespace RustPlusDesk.Services.Auth
             _lastBroadcastMasterSteamId = null;
             if (_broadcastChannel != null)
             {
-                try { _broadcastChannel.Unsubscribe(); } catch { }
+                DropChannel(_broadcastChannel);
                 _broadcastChannel = null;
                 _broadcast = null;
             }
@@ -216,9 +223,25 @@ namespace RustPlusDesk.Services.Auth
         {
             if (_presenceChannel != null)
             {
-                try { _presenceChannel.Unsubscribe(); } catch { }
+                DropChannel(_presenceChannel);
                 _presenceChannel = null;
             }
+        }
+
+        /// <summary>
+        /// Unsubscribes and then takes the channel out of the Realtime client entirely.
+        ///
+        /// Unsubscribe alone is not enough: the client keeps channels in a registry keyed by
+        /// topic, so a later Channel(sameName) hands back the very same object — and Register
+        /// may only be called on a channel once. Reconnecting to a server already used in this
+        /// session then failed with "Register can only be called with broadcast options for a
+        /// channel once", and stayed broken until the app was restarted, because every retry
+        /// received the same stale channel.
+        /// </summary>
+        private static void DropChannel(RealtimeChannel channel)
+        {
+            try { channel.Unsubscribe(); } catch { }
+            try { SupabaseAuthManager.Client?.Realtime?.Remove(channel); } catch { }
         }
 
         private static void UnsubscribeAll()

--- a/RustPlusDesktop/Services/CloudEventWatcher.cs
+++ b/RustPlusDesktop/Services/CloudEventWatcher.cs
@@ -474,7 +474,18 @@ public sealed class CloudEventWatcher
 
     private void UnsubscribeBroadcast()
     {
-        try { _channel?.Unsubscribe(); } catch { }
+        if (_channel != null)
+        {
+            try { _channel.Unsubscribe(); } catch { }
+
+            // Remove it from the client too, not just from here. The Realtime client keeps
+            // channels in a registry keyed by topic, so Channel(sameName) later returns this
+            // very object — and Register may only be called on a channel once. Reconnecting to
+            // a server already visited this session would otherwise throw and stay broken
+            // until restart. Same failure that killed clan chat on a server switch.
+            try { SupabaseAuthManager.Client?.Realtime?.Remove(_channel); } catch { }
+        }
+
         _channel = null;
         _broadcast = null;
     }

--- a/RustPlusDesktop/Services/DiscordBotListenerService.cs
+++ b/RustPlusDesktop/Services/DiscordBotListenerService.cs
@@ -368,6 +368,12 @@ public class DiscordBotListenerService
                 channel.Unsubscribe();
             }
             catch { }
+
+            // And out of the client's registry. Channels are cached by topic there, so the
+            // next Channel(discord_queue_<guild>) would hand back this same object — and
+            // Register may only run on a channel once. Listening to the same guild twice in
+            // one session would throw and never recover.
+            try { SupabaseAuthManager.Client?.Realtime?.Remove(channel); } catch { }
         }
 
         _activeChannels.Clear();

--- a/RustPlusDesktop/Views/Windows/PatchNotesWindow.xaml
+++ b/RustPlusDesktop/Views/Windows/PatchNotesWindow.xaml
@@ -33,6 +33,27 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <StackPanel x:Name="PatchNotesContent" Margin="0,0,0,12">
                     <!-- ============================================== -->
+                    <!-- NEW v8.0.2 HOTFIX PATCH NOTES -->
+                    <!-- ============================================== -->
+                    <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="10" Padding="10" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="v8.0.2 | Clan Chat &amp; Server Switching Hotfix" FontWeight="SemiBold" FontSize="16" Margin="0,0,0,8" Foreground="{DynamicResource Accent}"/>
+
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Clan chat stopped arriving after switching servers:</Run>
+                                Returning to a server you had already been connected to in the same session broke the live sync, in the app and in Discord, until the app was restarted. Realtime channels are cached by name inside the Supabase client, so asking for the same channel again handed back the one that was already registered &#x2014; and registering it a second time is not allowed. Channels are now removed from the client rather than only unsubscribed, including when a subscription fails, which is why a single failure used to last for the rest of the session.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Same fix applied to audio events and the Discord bot:</Run>
+                                Both used the identical pattern and would have failed the same way &#x2014; one on returning to a previous server, the other on listening to the same Discord guild twice.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6" Foreground="#D0D0D0">
+                                Thanks to <Run FontWeight="Bold">Makuko</Run> for finding this one and sending in the analysis.
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- ============================================== -->
                     <!-- NEW v8.0.1 HOTFIX PATCH NOTES -->
                     <!-- ============================================== -->
                     <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="10" Padding="10" Margin="0,0,0,10">


### PR DESCRIPTION
## RustPlusDesk 8.0.2 — Clan chat & server switching hotfix

### Fixed

- **Clan chat stopped arriving after switching servers.** Returning to a server
  you had already connected to in the same session broke the live sync — in the
  app and in Discord — until a restart. Realtime channels are cached by name
  inside the Supabase client, so requesting the same channel again returned the
  instance that was already registered, and registering it a second time throws.
  Channels are now removed from the client rather than only unsubscribed,
  including on the failure path — which is why one failed subscription used to
  last for the rest of the session.

- **Same pattern fixed in two more places:** the audio event watcher, which would
  have failed on returning to a previous server, and the Discord bot listener, on
  listening to the same guild twice.

Thanks to **Makuko** for finding and diagnosing this one.