### PR TITLE
docs: 8.0.4 notes, and the four fixes that shipped in 8.0.3 unlisted

### DIFF
--- a/RustPlusDesktop/RustPlusDesk.csproj
+++ b/RustPlusDesktop/RustPlusDesk.csproj
@@ -25,7 +25,7 @@
 
 	<PropertyGroup>
 		<!-- Single source of truth for app, assembly, package, UI, and installer versioning. -->
-		<Version>8.0.3</Version>
+		<Version>8.0.4</Version>
 		<Title>Rust+ Desk</Title>
 		<Authors>Pronwan</Authors>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>

--- a/RustPlusDesktop/Views/Windows/PatchNotesWindow.xaml
+++ b/RustPlusDesktop/Views/Windows/PatchNotesWindow.xaml
@@ -33,6 +33,27 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <StackPanel x:Name="PatchNotesContent" Margin="0,0,0,12">
                     <!-- ============================================== -->
+                    <!-- NEW v8.0.4 HOTFIX PATCH NOTES -->
+                    <!-- ============================================== -->
+                    <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="10" Padding="10" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="v8.0.4 | Oil Rig False Alarm Hotfix" FontWeight="SemiBold" FontSize="16" Margin="0,0,0,8" Foreground="{DynamicResource Accent}"/>
+
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Electric furnaces reported as an Oil Rig:</Run>
+                                Standing next to electric furnaces matched the Oil Rig cue continuously, and fourteen reports in forty-one seconds used up the hourly limit &#x2014; so a genuine Oil Rig in that same hour was refused as well. That was the real damage: the false alarms were rejected, but they took the real one with them.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Two changes, because one is not enough:</Run>
+                                Oil Rig now needs a clearly higher score than the other cues, since it has the narrowest margin of the three. And a genuine announcement is only ever reported once &#x2014; twice if both rigs fire together &#x2014; so anything still matching after that is treated as a continuous sound and ignored until it stops. Score alone could not separate them: machinery matches at a fresh alignment every time and slips straight past the duplicate check.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6" Foreground="#D0D0D0">
+                                The higher bar has a price worth naming: the faintest Oil Rig cue we ever confirmed would no longer clear it. Missing one distant announcement is the better trade, because the rig calls again on its cycle &#x2014; while an exhausted limit silences everything for an hour.
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- ============================================== -->
                     <!-- NEW v8.0.3 HOTFIX PATCH NOTES -->
                     <!-- ============================================== -->
                     <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource CardBorder}" BorderThickness="1" CornerRadius="10" Padding="10" Margin="0,0,0,10">
@@ -65,8 +86,24 @@
                                 <Run FontWeight="Bold">&#x2022; Same fix applied to audio events and the Discord bot:</Run>
                                 Both used the identical pattern and would have failed the same way &#x2014; one on returning to a previous server, the other on listening to the same Discord guild twice.
                             </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Camera picture was half black:</Run>
+                                Rust doubled the camera resolution to 320&#xD7;180 without sending more ray data, so the renderer &#x2014; which built every frame from a fixed ten packets, a number chosen when cameras were 160&#xD7;90 &#x2014; could only fill about half the pixels. The pixel buffer now persists and fills in progressively, the way the official Rust+ app does it, which also means a frame decodes one packet instead of ten.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Pairing without Google Chrome:</Run>
+                                Pairing needs a Chromium-based browser and only ever looked for Chrome where Chrome usually is. Without it a console window flashed for two seconds and nothing happened. Chrome, Edge, Brave, Vivaldi, Opera and Chromium are now all found, including installations in unusual locations, and the log says which one is being used.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Recovering from antivirus quarantine:</Run>
+                                Windows Defender sometimes removes individual files from the pairing runtime while leaving the folder behind. The app only checked that the folder existed, so it never repaired itself and pairing stayed broken until the folder was deleted by hand. It now checks the files that have to be there and re-extracts them on the next start.
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                                <Run FontWeight="Bold">&#x2022; Oil Rig triggers no longer call your phone:</Run>
+                                A Smart Alarm used as an oil rig trigger stopped raising a raid alert in the app, but the cloud service knew nothing about it and still placed a Telegram call for a crate hack. Which alarms are rig triggers is now shared with it, along with the text each alarm sends, so a crate hack reaches Discord labelled as one and leaves the phone alone.
+                            </TextBlock>
                             <TextBlock TextWrapping="Wrap" Margin="0,0,0,6" Foreground="#D0D0D0">
-                                Thanks to <Run FontWeight="Bold">Makuko</Run> for finding this one and sending in the analysis.
+                                Thanks to <Run FontWeight="Bold">Makuko</Run> for finding the server-switching bug and sending in the analysis.
                             </TextBlock>
                         </StackPanel>
                     </Border>


### PR DESCRIPTION
Version 8.0.4.

The 8.0.3 notes covered the two alarm fixes and the server-switching bug, but four user-visible changes went out with it undocumented: the camera picture being half black at the new resolution, pairing without Chrome installed, recovering from antivirus quarantine, and oil rig triggers no longer placing a Telegram call. Added where they belong, under 8.0.3, since that is the version people already have them in.

The 8.0.4 entry states the cost of the higher Oil Rig threshold rather than only the benefit — the faintest confirmed cue no longer clears it.